### PR TITLE
doc: build howto temporarily points to next in sof

### DIFF
--- a/howtos/process/docbuild.rst
+++ b/howtos/process/docbuild.rst
@@ -87,6 +87,10 @@ upstream project repos (though https clones work too):
    .. code-block:: bash
 
       git clone git@github.com:thesofproject/sof.git
+      # use next until merged back to master
+      cd sof
+      git checkout next
+      cd ..
 
 #. For the cloned local repos, tell git about the upstream repo:
 


### PR DESCRIPTION
This additional step is necessary until next is merged back to master.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>