### PR TITLE
doc: add under development header to pages

### DIFF
--- a/static/sof-custom.css
+++ b/static/sof-custom.css
@@ -10,14 +10,13 @@
     background-color: #33335b
 }
 
-/* (temporarily) add an under development tagline to the bread crumb
+/* (temporarily) add an under development tagline to the bread crumb */
 .wy-breadcrumbs::after {
    content: " (Content under development)";
    background-color: #FFFACD;
    color: red;
    font-weight: bold;
 }
-*/
 
 /* code block highlight color in rtd changed to lime green, no no no */
 


### PR DESCRIPTION
Uncomment the CSS style to show a "under development"
message under the breadcrumb trail at the top of the page

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>