### PR TITLE
doc: add wraping for unit tests

### DIFF
--- a/developer_guides/unit_tests.rst
+++ b/developer_guides/unit_tests.rst
@@ -56,7 +56,7 @@ Preparing cmocka package
 
 1. Build cmocka with static library on:
 
-   .. code-block:: bash
+.. code-block:: bash
 
       cmake <cmocka src dir> -DWITH_STATIC_LIB=ON
 
@@ -69,7 +69,7 @@ Preparing cmocka package
 #. Mkdir for package to be referenced by main sof build script and copy
    required files there:
 
-   .. code-block:: bash
+.. code-block:: bash
 
       mkdir /home/<you>/cminstall
       mkdir /home/<you>/cminstall/include
@@ -80,9 +80,46 @@ Preparing cmocka package
 
 #. Use the target location for cmocka files when invoking *configure* script:
 
-   .. code-block:: bash
+.. code-block:: bash
 
       ./configure --with-cmocka-prefix=/home/<you>/cminstall ...
+
+Wrapping objects for unit tests
+******************************
+
+If you need to mock a symbol, define it in a unit test and include the .h file. 
+There are 2 cases where this isn't possible:
+
+*	Static functions in headers(those most probably are inline short functions
+	and don't have to be mocked)
+
+*	Static functions that are in the same file as tested functionality and are
+	exceedingly large so they can't be tested as one functionality. 
+
+Whatever the reason, mocking of those symbols can be done by using --wrap linker
+functionality. To wrap the symbol follow these steps:
+
+#. Create mocked symbol named __wrap_symbol_name
+
+#. Pass instruction for the linker -Wl, --wrap=symbol_name during compilation.
+
+Now every symbol call to symbol_name will call __wrap_symbol_name.
+
+Instructions can be passed to the linker in the SOF UT environment using
+CFLAGS, however they should be passed in separate variables in the makefile.
+
+Example:
+
+.. code-block:: bash
+ 
+	  # some tests before ...
+          check_PROGRAMS += pipeline_connect_upstream
+          pipeline_connect_upstream_SOURCES = ../../src/audio/pipeline.c src/audio/pipeline/ pipeline_mocks.c src/audio/pipeline/pipeline_connect_upstream.c src/audio/pipeline/pipeline_mocks_rzalloc.c
+          pipeline_connect_upstream_CFLAGS = -Wl, --wrap=symbol_name
+
+Full information about wrapping can be found here:
+
+https://lwn.net/Articles/558106/
 
 Notes
 *****
@@ -95,6 +132,6 @@ Notes
 
 #. To speed up development of new unit tests you can run specific tests like:
 
-   .. code-block:: bash
+.. code-block:: bash
 
       make check check_PROGRAMS="testname1 testname2"


### PR DESCRIPTION
Added guide for symbol wraping in unit tests.

Signed-off-by: Jakub Dabek <jakub.dabek@linux.intel.com>