### PR TITLE
doc: fix Makefile for publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ clean:
 # along with a README
 
 publish:
+	cd $(PUBLISHDIR)/..; git pull origin master
 	mkdir -p $(PUBLISHDIR)
 	rm -fr $(PUBLISHDIR)/*
 	cp -r $(BUILDDIR)/html/* $(PUBLISHDIR)


### PR DESCRIPTION
Publishing should first pull a current copy of the publishing repo from
github locally before updating with locally generated content (in case
the publishing was done by someone else).

Signed-off-by: David B. Kinder <david.b.kinder@intel.com>