### PR TITLE
Add required Ubuntu packages

### DIFF
--- a/howtos/process/docbuild.rst
+++ b/howtos/process/docbuild.rst
@@ -136,7 +136,7 @@ Depending on your Linux version, install the needed tools:
   .. code-block:: bash
 
      sudo apt-get install doxygen python3-pip python3-wheel make \
-        default-jre graphviz
+        default-jre graphviz python3-sphinx python3-breathe
 
 * For Fedora use:
 


### PR DESCRIPTION
The packages python3-sphinx python3-breathe are needed on
Ubuntu 18.04. To get "make html" work.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>