### PR TITLE
build: from scratch: fix apollolake config

### DIFF
--- a/getting_started/build-guide/build-from-scratch.rst
+++ b/getting_started/build-guide/build-from-scratch.rst
@@ -266,7 +266,7 @@ for |APL|:
 
 .. code-block:: bash
 
-    $ ./configure --with-arch=xtensa-smp --with-platform=broxton --with-root-dir=`pwd`/../xtensa-root/xtensa-bxt-elf --host=xtensa-bxt-elf
+    $ ./configure --with-arch=xtensa-smp --with-platform=apollolake --with-root-dir=`pwd`/../xtensa-root/xtensa-apl-elf --host=xtensa-apl-elf
     $ make
     $ make bin
 


### PR DESCRIPTION
While following this article I had to change these values to be able to build sof for apl. I guess that makes sense because you have no broxton in xtensa-root and toolchain so it cannot get headers + cannot find binary for *bxt-gcc, because we prepared them for apl in earlier step.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>