### PR TITLE
CI: enable travis CI for sof-docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+dist: xenial
+
+language: python
+
+python:
+    - "3.6"
+
+before_install:
+    - sudo apt-get update -qq
+    - sudo apt-get install doxygen make default-jre graphviz cmake
+
+install:
+    - pip install -r scripts/requirements.txt
+
+script:
+    - cd .. && git clone https://github.com/thesofproject/sof.git && cd sof/doc && cmake . && make doc && cd - && cd sof-docs
+    - make html
+    - ls _build


### PR DESCRIPTION
Use Python 3.6 to build the html
Build sof doc with doxygen

Logs can be found here https://travis-ci.org/xiulipan/sof-docs

TODO: how to deploy the static html to https://github.com/thesofproject/thesofproject.github.io

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>