### PR TITLE
Small fix to up 2 board setup

### DIFF
--- a/getting_started/setup/setup_up_2_board.rst
+++ b/getting_started/setup/setup_up_2_board.rst
@@ -109,4 +109,4 @@ Make sure the green LED lights up on the Hifiberry.
 
 .. note::
 
-   If any problem has occured use 'dmesg | grep sof' to track it.
+   If any problem has occured use ``dmesg | grep sof`` to track it.

--- a/getting_started/setup/setup_up_2_board.rst
+++ b/getting_started/setup/setup_up_2_board.rst
@@ -109,4 +109,4 @@ Make sure the green LED lights up on the Hifiberry.
 
 .. note::
 
-   If any problem has occured use 'dmesg |grep sof' to track it.
+   If any problem has occured use 'dmesg | grep sof' to track it.


### PR DESCRIPTION
Started out correcting a parsing error (line 112 of setup_up_2_board.rst) and went ahead and switched from quotes to inline code block.