### PR TITLE
add to install fftw3 library before alsa-utils

### DIFF
--- a/getting_started/build-guide/build-from-scratch.rst
+++ b/getting_started/build-guide/build-from-scratch.rst
@@ -84,6 +84,12 @@ the newest ALSA from source code.
    ./gitcompile
    sudo make install
 
+
+(Optional) To enable alsabat's frequency analysis, FFT library should be installed before configuring alsa-utils.
+.. code-block:: bash
+
+   sudo apt-get install libfftw3-dev libfftw3-doc
+
 Clone, build, and install alsa-utils.
 
 .. code-block:: bash


### PR DESCRIPTION
FFT library is required to enable alsabat's frequency analysis. This is
optional, Instead of putting this in top build dependency, fftw3 is added
as one optional step before building alsa-utils.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>