### PR TITLE
Add "pages" deploy from publish branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ deploy:
       on:
         branch: publish
       local_dir: _build/html/
-
+      target_branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,10 @@ script:
     - cd .. && git clone https://github.com/thesofproject/sof.git && cd sof/doc && cmake . && make doc && cd - && cd sof-docs
     - make html
     - ls _build
+    - mv _build/html _build/html/latest
     - touch _build/html/.nojekyll
+    - mv scripts/publish-README.md _build/html/README.md
+    - mv scripts/publish-index.html _build/html/index.html
 
 deploy:
     - provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ script:
     - cd .. && git clone https://github.com/thesofproject/sof.git && cd sof/doc && cmake . && make doc && cd - && cd sof-docs
     - make html
     - ls _build
+
+before_deploy:
     - mkdir _build/latest
     - mv -v _build/html/* _build/latest
     - mv _build/latest _build/html

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,14 @@ script:
     - cd .. && git clone https://github.com/thesofproject/sof.git && cd sof/doc && cmake . && make doc && cd - && cd sof-docs
     - make html
     - ls _build
+    - touch _build/html/.nojekyll
+
+deploy:
+    - provider: pages
+      skip_cleanup: true
+      github_token: $GITHUB_TOKEN
+      repo: thesofproject/thesofproject.github.io
+      on:
+        branch: publish
+      local_dir: _build/html/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ script:
     - cd .. && git clone https://github.com/thesofproject/sof.git && cd sof/doc && cmake . && make doc && cd - && cd sof-docs
     - make html
     - ls _build
-    - mkdir _build/html/latest
-    - mv -v _build/html/* _build/html/latest
+    - mkdir _build/latest
+    - mv -v _build/html/* _build/latest
+    - mv _build/latest _build/html
     - touch _build/html/.nojekyll
     - mv scripts/publish-README.md _build/html/README.md
     - mv scripts/publish-index.html _build/html/index.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ script:
     - cd .. && git clone https://github.com/thesofproject/sof.git && cd sof/doc && cmake . && make doc && cd - && cd sof-docs
     - make html
     - ls _build
-    - mv _build/html _build/html/latest
+    - mkdir _build/html/latest
+    - mv -v _build/html/* _build/html/latest
     - touch _build/html/.nojekyll
     - mv scripts/publish-README.md _build/html/README.md
     - mv scripts/publish-index.html _build/html/index.html


### PR DESCRIPTION
Commits to publish branch will now result in deploying of static HTML to thesofproject.github.io.

This simplifies the publish process removing the need to build it locally and use the "make publish" command.

The manual process can still be used when/if needed.