### PR TITLE
platforms: Update info for Broadwell

### DIFF
--- a/platforms/intel-legacy/broadwell/index.rst
+++ b/platforms/intel-legacy/broadwell/index.rst
@@ -7,7 +7,11 @@ Intel Broadwell platform is based on an core CPU and a Tensilica HiFi2
 EP DSP integrated in the PCH. It relies only on internal memory (no
 caches).
 
-Supported commercially-available platforms are limited. The SOF team
-is only aware of the Chromebook Pixel 2015 (code name "samus") and the
-Dell XPS.
+Supported commercially-available platforms are limited, but include:
+
+- Dell Latitude 13 7350 2-in-1 laptop
+- Dell Venue 11 Pro 7140 tablet
+- Dell XPS 13 9343 laptop
+- Google Chromebook Pixel (2015)
+- HP Spectre x360 (2015) 2-in-1 laptop
 


### PR DESCRIPTION
Because of kernel bug 204237 (and downstream Fedora bug 1750194), we know about more devices which use this platform.