### PR TITLE
doc: removed "How-tos" title frm Index since section is gone.

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -31,7 +31,6 @@ Sections
    platforms/index.rst
    developer_guides/index.rst
    release.rst
-   howtos/index.rst
    contribute/index.rst
    api/index.rst
    presentations/index.rst


### PR DESCRIPTION
Signed-off-by: Deb Taylor <deb.taylor@intel.com>