### PR TITLE
Scale down diagrams for Keyword Detection feature

### DIFF
--- a/developer_guides/firmware/kd_integration/images/kd-component-diagram.pu
+++ b/developer_guides/firmware/kd_integration/images/kd-component-diagram.pu
@@ -1,6 +1,6 @@
 @startuml
 
-'scale max 800 height
+scale max 1024 width
 
 skinparam rectangle {
    backgroundColor<<dai>> #6fccdd

--- a/developer_guides/firmware/kd_integration/images/kd-e2e-sequence-diagram.pu
+++ b/developer_guides/firmware/kd_integration/images/kd-e2e-sequence-diagram.pu
@@ -1,4 +1,7 @@
 @startuml
+
+scale max 1024 width
+
 participant "Userspace component" as usr
 participant "Audio driver" as drv
 participant "FW infrastructure" as fw

--- a/developer_guides/firmware/kd_integration/images/kd-timing-diagram.pu
+++ b/developer_guides/firmware/kd_integration/images/kd-timing-diagram.pu
@@ -1,4 +1,7 @@
 @startuml
+
+scale max 1024 width
+
 footer: timeline not to scale 
 robust "Speech Application" as App
 concise "Audio Stream" as Audio


### PR DESCRIPTION
The diagrams have fixed maximum width to make them fit reading pane on low
resolution monitors.

Signed-off-by: Lech Betlej <lech.betlej@linux.intel.com>