### PR TITLE
api: add reference to pm-runtime dox

### DIFF
--- a/api/index.rst
+++ b/api/index.rst
@@ -8,6 +8,7 @@ API Documentation
 
    dma-drivers-api
    dai-drivers-api
+   pm-runtime-api
    platform-api
    component-api
    uapi

--- a/api/pm-runtime-api.rst
+++ b/api/pm-runtime-api.rst
@@ -1,0 +1,7 @@
+.. _pm-runtime-api:
+
+PM Runtime API
+##############
+
+.. doxygengroup:: pm_runtime
+   :project: SOF Project


### PR DESCRIPTION
Documentation for pm-runtime API should be included.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>