### PR TITLE
sof-docs: Add TSC and maintainers documentation

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -32,5 +32,7 @@ Sections
    developer_guides/index.rst
    release.rst
    contribute/index.rst
+   tsc/index.rst
+   maintainers/index.rst
    api/index.rst
    presentations/index.rst

--- a/maintainers/admin.rst
+++ b/maintainers/admin.rst
@@ -1,0 +1,28 @@
+.. _admin:
+
+SOF admin
+#########
+
+Given the size of the project, maintainer rights are granted
+to multiple contributors:
+
++---------------+-------------------+---------------+
+| Intel 	| Lech Betlej       | @lbetlej 	    |
++---------------+-------------------+---------------+
+| Intel	        | Liam Girdwood     | @lgirdwood    |
++---------------+-------------------+---------------+
+| Intel 	| Marcin Maka       | @mmaka1	    |
++---------------+-------------------+---------------+
+| Intel	        | Pierre Bossart    | @plbossart    |
++---------------+-------------------+---------------+
+| Intel         | Ranjani Sridharan | @ranj063      |
++---------------+-------------------+---------------+
+| NXP           | Daniel Baluta     | @dbaluta      |
++---------------+-------------------+---------------+
+
+Administrators may override specific merge rules, for example merge a
+PR even if it does not meet all criteria defined by a repository, but
+will only do so for exceptional cases.
+
+Administrators can add new contributors to the project, define their
+contributor levels and assign them to specific teams.

--- a/maintainers/code_owners.rst
+++ b/maintainers/code_owners.rst
@@ -1,0 +1,16 @@
+.. _code_owners:
+
+
+SOF code owners
+###############
+
+Each repository defines its own CODE_OWNER file, which identifies key
+contributors and experts in each area of the SOF project.
+
+Code owners will be notified of each change to their respective
+domains, and are encouraged to approve or provide feedback on
+contributions being reviewed.
+
+Each repository in the SOF project may define their own rules, but the
+general expectation is that Pull Requests are approved by 2 or more
+code owners, maintainers or admin.

--- a/maintainers/index.rst
+++ b/maintainers/index.rst
@@ -1,0 +1,15 @@
+.. _maintainers:
+
+
+SOF admin, maintainers and code owners
+######################################
+
+The SOF project defines administrators, grants key contributors merge
+rights and defines code owners for each subsystem and technical area.
+
+.. toctree::
+   :maxdepth: 1
+
+   admin.rst
+   merge_rights.rst
+   code_owners.rst

--- a/maintainers/merge_rights.rst
+++ b/maintainers/merge_rights.rst
@@ -1,0 +1,13 @@
+.. _merge_rights:
+
+Merge rights
+############
+
+For the firmware tree, additional key contributors have merge rights
+into the master branch:
+
++---------------+-------------------+---------------+
+| Intel 	| Tomasz Lauda      | @tlauda 	    |
++---------------+-------------------+---------------+
+| Intel	        | Janusz Jankowski  | @jajanusz     |
++---------------+-------------------+---------------+

--- a/tsc/index.rst
+++ b/tsc/index.rst
@@ -1,0 +1,15 @@
+.. _tsc:
+
+Technical Steering Committee (TSC)
+##################################
+
+The TSC serves as the highest technical decision body for the project,
+with members chosen from involved project maintainers. This committee
+sets the technical direction for the project, defines milestone
+release features, and coordinates cross-community collaboration.
+
+.. toctree::
+   :maxdepth: 1
+
+   representatives.rst
+   meetings.rst

--- a/tsc/meetings.rst
+++ b/tsc/meetings.rst
@@ -1,0 +1,12 @@
+.. _meetings:
+
+TSC Meetings
+############
+
+TSC meetings take place every month, typically the first Monday of
+each month, with a agenda circulated ahead of time on the SOF mailing
+list.
+
+The notes and decisions made by the TSC will be made public, stored on
+GitHub and a link provided on the SOF mailing list.
+

--- a/tsc/representatives.rst
+++ b/tsc/representatives.rst
@@ -1,0 +1,23 @@
+.. _representatives:
+
+
+TSC Representatives
+###################
+
+The TSC is currently made of the following contributors
+
++---------------+-------------------+---------------+
+| Intel 	| Lech Betlej       | @lbetlej 	    |
++---------------+-------------------+---------------+
+| Intel	        | Liam Girdwood     | @lgirdwood    |
++---------------+-------------------+---------------+
+| Intel 	| Marcin Maka       | @mmaka1	    |
++---------------+-------------------+---------------+
+| Intel	        | Pierre Bossart    | @plbossart    |
++---------------+-------------------+---------------+
+| NXP           | Daniel Baluta     | @dbaluta      |
++---------------+-------------------+---------------+
+| Google        | Curtis Malainey   | @cujomalainey |
++---------------+-------------------+---------------+
+| Google        | Dylan Reid        | @dgreid       |
++---------------+-------------------+---------------+


### PR DESCRIPTION
document who's who in the SOF project

This is a first pass for review, feedback welcome