### PR TITLE
pm-runtime: add basic documentation of pm transitions

### DIFF
--- a/developer_guides/firmware/index.rst
+++ b/developer_guides/firmware/index.rst
@@ -10,6 +10,7 @@ Developer guides and information for firmware development.
 
    component-tutorial/tut-intro
    mem-mgmt
+   pm-runtime/index
    work-queue
    drivers/index
    components/index

--- a/developer_guides/firmware/pm-runtime/images/pm-dsp-core-idle.pu
+++ b/developer_guides/firmware/pm-runtime/images/pm-dsp-core-idle.pu
@@ -1,0 +1,28 @@
+scale max 800 width
+
+participant drv as "Driver"
+participant ipc
+participant mct as "master-core-task"
+participant platform
+participant pm_rt as "pm-runtime"
+
+drv -> ipc : PM_GATE (PPG = 0)
+note left: Entering idle...
+   activate ipc
+   ipc -> pm_rt : <b>pm_runtime_enable(PM_RUNTIME_DSP, 0)</b>
+      activate pm_rt
+      pm_rt -> pm_rt : ref_cnt--
+         note right: 1 -> 0 (if there was no other disable calls)
+   ipc <-- pm_rt
+   deactivate pm_rt
+drv <-- ipc
+deactivate ipc
+
+mct -> platform : <i>platform_wait_for_interrupt()</i>
+   activate platform
+   platform -> pm_rt : <b>pm_runtime_is_active(PM_RUNTIME_DSP, 0)</b>
+      activate pm_rt
+   platform <-- pm_rt : false
+   deactivate pm_rt
+   platform -> platform : d?-idle state if available
+   deactivate platform

--- a/developer_guides/firmware/pm-runtime/images/pm-dsp-core-init.pu
+++ b/developer_guides/firmware/pm-runtime/images/pm-dsp-core-init.pu
@@ -1,0 +1,34 @@
+scale max 800 width
+
+participant drv as "Driver"
+participant ipc
+participant mct as "master-core-task"
+participant platform
+participant pm_rt as "pm-runtime"
+
+mct -> platform : platform_init()
+   activate platform
+
+   platform -> pm_rt :<b> pm_runtime_disable(PM_RUNTIME_DSP, 0)</b>
+      activate pm_rt
+      note right: Make latency of dsp core 0 int handler minimal
+      pm_rt -> pm_rt : ref_cnt++
+         note right: 0 -> 1
+   platform <-- pm_rt
+   deactivate pm_rt
+
+mct <-- platform
+deactivate platform
+
+drv -> ipc : building topology
+   ipc -> mct
+      mct -> platform : <i>platform_wait_for_interrupt()</i>
+         activate platform
+         platform -> pm_rt : <b>pm_runtime_is_active(PM_RUNTIME_DSP, 0)</b>
+            activate pm_rt
+         platform <-- pm_rt : true
+         deactivate pm_rt
+         platform -> platform : d0-idle state
+         deactivate platform
+   ipc <-- mct
+drv <-- ipc

--- a/developer_guides/firmware/pm-runtime/index.rst
+++ b/developer_guides/firmware/pm-runtime/index.rst
@@ -1,0 +1,15 @@
+.. _kernel-pm-runtime:
+
+Power Management
+################
+
+.. toctree::
+   :maxdepth: 1
+
+   pm-dsp-core
+   intel/pm-dsp-core-cavs
+
+API
+***
+
+:ref:`pm-runtime-api`

--- a/developer_guides/firmware/pm-runtime/intel/images/dsp-core-lps-cavs-d0-d0i3-d0.pu
+++ b/developer_guides/firmware/pm-runtime/intel/images/dsp-core-lps-cavs-d0-d0i3-d0.pu
@@ -1,0 +1,37 @@
+scale max 800 width
+
+participant platform
+participant lps as "cavs/lps_wait"
+participant lps_pg as "cavs/lps\npg thread"
+participant pm_rt as "pm-runtime"
+
+participant lpsram_boot as "Lpsram\nBoot"
+participant dsp_rom as "Dsp\nRom"
+
+-> platform : platform_wait_for_interrupt()
+   activate platform
+   platform -> lps : lps_wait_for_interrupt()
+      activate lps
+      lps -> lps : platform_pg\nint_handler(D0i3/D0) [SW INT]
+         activate lps
+         lps -> pm_rt : <b>pm_runtime_put(DSP, 0)</b>
+            note right: DSP core PG\nenabled
+         lps -> lps_pg : platform_pg_task
+         deactivate lps
+            activate lps_pg
+               lps_pg -> lps_pg : configure lpsram boot
+               lps_pg -> lps_pg : waiti
+                  note right: DSP core is PG-ed
+               deactivate lps_pg
+...
+
+dsp_rom <- : INT
+lpsram_boot <- dsp_rom
+lps <- lpsram_boot : platform_pg\nint_handler(D0i3/D0) [SW INT]
+   activate lps
+   lps -> pm_rt : <b>pm_runtime_get(DSP, 0)
+      note right: DSP core PG\ndisabled
+   lps <-- lps
+   deactivate lps
+platform <-- lps
+<-- platform

--- a/developer_guides/firmware/pm-runtime/intel/pm-dsp-core-cavs.rst
+++ b/developer_guides/firmware/pm-runtime/intel/pm-dsp-core-cavs.rst
@@ -1,0 +1,30 @@
+.. _pm-dsp-core-cavs:
+
+cAVS pm-runtime for DSP core 0
+##############################
+
+cAVS provides two levels of power savings for DSP cores:
+
+- clock gating,
+
+- power gating in idle, important part of *D0i3* state.
+
+The clock gating is enabled by default. When a DSP core enters idle (calls
+``waiti``), the clock signal is gated (note that ``CCOUNT`` is not incremented
+in this state, so the only reliable always running clock is the Wall Clock).
+
+The power gating mechanism is enabled if the *CAVS_LPS* config option is set.
+The ``waiti`` entry/exit transitions are driven by the Low Power Sequencer
+(LPS). The platform is able to shut the DSP core down on ``waiti`` and power
+it up on interrupt.
+
+The LPS mechanism is used only if ``pm_runtime_is_active()`` returns *false*
+meaning that DPS core 0 does not have to be locked in D0 state.
+
+Implementation note: cAVS simply uses ``pm_runtime_get()``
+/``pm_runtime_put()`` operations to program the power gating control registers
+in D0i3 to indicate that DSP core should be powered down/up while
+entering/exiting ``waiti``.
+
+.. uml:: images/dsp-core-lps-cavs-d0-d0i3-d0.pu
+   :caption: DSP Core 0 idle in D0i3 on cAVS with LPS

--- a/developer_guides/firmware/pm-runtime/pm-dsp-core.rst
+++ b/developer_guides/firmware/pm-runtime/pm-dsp-core.rst
@@ -1,0 +1,41 @@
+.. _pm-dsp-core:
+
+Power Management for DSP Cores
+##############################
+
+DSP cores are managed by using ``PM_RUNTIME_DSP`` context id and core index to
+the pm-runtime functions.
+
+Some platforms may provide advanced power management of the DSP cores,
+including clock gating in idle, full power gating in idle, etc. depending on
+how the cores are integrated on that platform.
+
+An implementation of platform API may provide customized idle entry function
+``platform_wait_for_interrupt()`` which might simply call
+``arch_wait_for_interrupt()`` or perform more sophisticated power transition to
+lower the power consumed when a DSP core is in idle.
+
+An advanced power transitions may take more time to complete since the DSP core
+/ platform has to return from a deeper power state. This additional latency is
+not always acceptable, for instance it might be better to complete the initial
+platform setup faster, with a quicker IPC request handling. Therefore the
+platform initialization code (``platform_init()``) may disable the advanced
+pm-runtime of the DSP core by calling ``pm_runtime_disable(PM_RUNTIME_DSP, 0)``
+and wait for the driver to enable it once the initialization is complete by
+sending ``PM_GATE (PreventPowerGating=0)`` IPC. The ``PM_GATE`` handler calls
+either ``pm_runtime_enable(PM_RUNTIME_DSP, 0)`` or
+``pm_runtime_disable(PM_RUNTIME_DSP, 0)`` depending on the value of the ``PPG``
+flag. Note that enable/disable calls are ref-counted as there might be other
+internal clients interested in locking the DSP core in the highest state in
+order to keep the ``waiti`` entry/exit latency minimal and get better
+performance.
+
+``pm_runtime_is_active(PM_RUNTIME_DSP, 0)`` may be used to query the state of
+ref-counter and decide whether transitions to deeper power states are allowed
+inside the ``platform_wait_for_interrupt()``.
+
+.. uml:: images/pm-dsp-core-init.pu
+   :caption: Pm-runtime: DSP Core 0 initial setup
+
+.. uml:: images/pm-dsp-core-idle.pu
+   :caption: Pm-runtime: DSP Core 0 enters idle


### PR DESCRIPTION
There are two parts: generic one, applicable for any platform
and another detailed one that documents cAVS advanced power
management of DSP core in deeper power states (D0i3).

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>