### PR TITLE
platforms: add description of Tigerlake platform

### DIFF
--- a/platforms/intel-cavs/images/cavs-platform-deps.pu
+++ b/platforms/intel-cavs/images/cavs-platform-deps.pu
@@ -1,4 +1,5 @@
 package cavs {
+   component 2.5
    component 2.0
    component 1.8
    component 1.5
@@ -13,13 +14,16 @@ package arch {
 1.5 ..> xtensa_smp
 1.8 ..> xtensa_smp
 2.0 ..> xtensa_smp
+2.5 ..> xtensa_smp
 
 package platform {
    component icelake
    component cannonlake
    component apollolake
+   component tigerlake
 }
 
 apollolake ..> 1.5
 cannonlake ..> 1.8
 icelake ..> 2.0
+tigerlake ..> 2.5

--- a/platforms/intel-cavs/index.rst
+++ b/platforms/intel-cavs/index.rst
@@ -11,6 +11,8 @@ Intel CAVS platforms supported by the |SOF|.
 |         |ver. 1.8  | Cannon Lake, Whisky Lake, Comet Lake    |
 |         +----------+-----------------------------------------+
 |         |ver. 2.0  | Ice Lake                                |
+|         +----------+-----------------------------------------+
+|         |ver. 2.5  | Tiger Lake                              |
 +---------+----------+-----------------------------------------+
 
 .. note:: while the Sky Lake and Kaby Lake platforms are also based on the
@@ -27,3 +29,4 @@ Intel CAVS platforms supported by the |SOF|.
    apollolake/index
    cannonlake/index
    icelake/index
+   tigerlake/index

--- a/platforms/intel-cavs/tigerlake/images/tgl-memory.dot
+++ b/platforms/intel-cavs/tigerlake/images/tgl-memory.dot
@@ -1,0 +1,24 @@
+digraph G {
+  node [fontsize=10, shape="record"]
+  edge [fontsize=10]
+  rankdir=LR
+  splines=line
+
+  dsp [label="DSP"]
+  mem_rom [label="<rom>ROM\n9F18 00000\n(512KB)"]
+  mem_alias [label="<a>Alias\n8000 0000\n" group="memory"]
+  mem [label="<imr> IMR\nB000 0000
+            |<hpsram> HPSRAM\nBE00 0000
+            |<lpsram> LPSRAM\nBE80 0000
+	    |<l1dsram> L1DSRAM\n9F10 000 
+	    |<l1isram> L1ISRAM\n9F18 0000" group="memory"]
+
+  dsp -> mem_alias:a [label="L1 uncached"]
+
+  dsp -> mem:imr [label="L1 cached"]
+  dsp -> mem:hpsram [label="L1 cached"]
+  dsp -> mem:lpsram [label="L1 cached"]
+
+  dsp -> mem:l1dsram [label="L1 local"]
+  dsp -> mem:l1isram [label="L1 local"]
+}

--- a/platforms/intel-cavs/tigerlake/index.rst
+++ b/platforms/intel-cavs/tigerlake/index.rst
@@ -1,0 +1,13 @@
+.. _platform-tigerlake:
+
+Intel Tiger Lake
+#################
+
+Intel Tiger Lake (TGL) platform is built on cAVS 2.5 HW and uses Xtensa DSP
+architecture.
+
+.. toctree::
+   :maxdepth: 1
+
+   tgl-memory
+   tgl-config

--- a/platforms/intel-cavs/tigerlake/tgl-config.rst
+++ b/platforms/intel-cavs/tigerlake/tgl-config.rst
@@ -1,0 +1,9 @@
+.. _tgl-config:
+
+TGL Configuration
+#################
+
+Supported DAIs
+**************
+
+- SSP: 6 instances exposed via ``dai_get()``.

--- a/platforms/intel-cavs/tigerlake/tgl-memory.rst
+++ b/platforms/intel-cavs/tigerlake/tgl-memory.rst
@@ -1,0 +1,40 @@
+.. _tgl-memory:
+
+TGL Memory
+##########
+
+8000 0000h
+   Aliasing to A000 0000h - BFFF FFFFh range (non L1 cacheable).
+
+A000 0000h
+   L2 cacheable memory (L1 cacheable).
+
+B000 0000h
+   L2 uncacheable memory (L1 cacheable).
+   IMR (4MB size), see *IMR Allocation*
+
+BE00 0000h
+   L2 local HPSRAM (L1 cacheable).
+   Seen as 8MB of virtual memory space (48 * 64KB).
+
+BE80 0000h
+   L2 local LPSRAM (L1 cacheable).
+   Directly accessed LPSRAM (64KB).
+
+9F00 0000h
+   L1 local D-SRAM (512 KB)
+   Directly accessed from core #0 only.
+
+9F10 0000h
+   L1 local I-SRAM (512 KB)
+   Directly accessed from core #0 only.
+
+.. note:: SOF version that will add Local L1 Data & Instruction SRAM support
+          is a subject to future development.
+
+9F18 0000h
+   DSP ROM Code
+   Directly accessed from core #0 only.
+
+   .. graphviz:: images/tgl-memory.dot
+      :caption: TGL Memory Map


### PR DESCRIPTION
The change adds high level description of Tigerlake hw (cavs 2.5).
Specifically support for L1 ROM and L1 data / instruction SRAM
are new in comparison to Cannonlake (cavs 1.8).

Signed-off-by: Lech Betlej <lech.betlej@linux.intel.com>