### PR TITLE
platforms: update Icelake configuration details

### DIFF
--- a/platforms/intel-cavs/icelake/icl-config.rst
+++ b/platforms/intel-cavs/icelake/icl-config.rst
@@ -1,0 +1,9 @@
+.. _icl-config:
+
+ICL Configuration
+#################
+
+Supported DAIs
+**************
+
+- SSP: 6 instances exposed via ``dai_get()``.

--- a/platforms/intel-cavs/icelake/icl-memory.rst
+++ b/platforms/intel-cavs/icelake/icl-memory.rst
@@ -1,0 +1,6 @@
+.. _icl-memory:
+
+ICL Memory
+##########
+
+Memory map is the same as on Cannonlake. See :ref:`cnl-memory`.

--- a/platforms/intel-cavs/icelake/index.rst
+++ b/platforms/intel-cavs/icelake/index.rst
@@ -5,3 +5,10 @@ Intel Ice Lake
 
 The Intel Ice Lake (ICL) platform is built on cAVS 2.0 HW and uses Xtensa DSP
 architecture.
+
+
+.. toctree::
+   :maxdepth: 1
+
+   icl-memory
+   icl-config


### PR DESCRIPTION
The change clarifies that memory map used by Icelake platform
is the same as on Cannonlake. The SSP DAI number is updated.

Signed-off-by: Lech Betlej <lech.betlej@linux.intel.com>