### PR TITLE
platforms: clarify HP/LP SRAM access modes

### DIFF
--- a/platforms/intel-cavs/cannonlake/cnl-memory.rst
+++ b/platforms/intel-cavs/cannonlake/cnl-memory.rst
@@ -15,11 +15,15 @@ B000 0000h
 
 BE00 0000h
    L2 local HPSRAM (L1 cacheable).
-   Seen as 8MB of virtual memory space (48 * 64KB).
+   Seen as 8MB of virtual memory space (47 * 64KB).
+
+.. note:: By default address virtualization is disabled. The Translation Lookup
+          Buffer (TLB) entries for populated HPSRAM banks have the same values
+          for virtual addresses as HPSRAM banks physical addresses.
 
 BE80 0000h
    L2 local LPSRAM (L1 cacheable).
-   Directly accessed LPSRAM (64KB).
+   Accessed using physical addresses. (1 * 64KB).
 
 BEFE 0000h
    DSP ROM Code

--- a/platforms/intel-cavs/tigerlake/tgl-memory.rst
+++ b/platforms/intel-cavs/tigerlake/tgl-memory.rst
@@ -15,11 +15,15 @@ B000 0000h
 
 BE00 0000h
    L2 local HPSRAM (L1 cacheable).
-   Seen as 8MB of virtual memory space (48 * 64KB).
+   Seen as 8MB of virtual memory space (46 * 64KB).
+
+.. note:: By default address virtualization is disabled. The Translation Lookup
+          Buffer (TLB) entries for populated HPSRAM banks have the same values
+          for virtual addresses as HPSRAM banks physical addresses.
 
 BE80 0000h
    L2 local LPSRAM (L1 cacheable).
-   Directly accessed from LPSRAM (64KB).
+   Accessed using physical addresses. (1 * 64KB).
 
 9F00 0000h
    L1 local D-SRAM (512 KB)


### PR DESCRIPTION
The memory maps for cavs 1.8/2.5 have to reflect both hw capabilities (like
support for large virtual memory space that can be mapped to HPSRAM of a
limited size) and current fw configuration. HW does not support address
virtualization for LPSRAM. Number of physical HPSRAM banks for Cannonlake
was updated.

Signed-off-by: Lech Betlej <lech.betlej@linux.intel.com>