### PR TITLE
developer_guides: introduction: fix misspellings

### DIFF
--- a/developer_guides/introduction.rst
+++ b/developer_guides/introduction.rst
@@ -7,8 +7,8 @@ Introduction
 some DSP intrinsics for media processing. The intended audience is software 
 developers familiar with C programming and media processing.
 
-Developers wishing to participate with upstream should also be familar with
-git and also with github.
+Developers wishing to participate with upstream should also be familiar with
+git and also with GitHub.
 
 Knowledge of hardware debugging (e.g. JTAG) and use of emulators is also 
 desirable if bringing up new hardware.
@@ -22,11 +22,11 @@ developers.
 
 **Component** An audio or signal processing component that processes input 
 data into output data. Components can have one or more input source buffers and 
-once or more output sink buffers. Components can also send and recieve runtime 
+one or more output sink buffers. Components can also send and receive runtime 
 configuration data that can be used to monitor or alter the data processing.
 
 **Buffer** A memory region that can be used to share audio processing data 
-between components. Buffers can have certain attributes depending on thier 
+between components. Buffers can have certain attributes depending on their
 usage. e.g. DMA'able buffer.
 
 **Pipeline** A collection of audio processing components and buffers that 
@@ -36,12 +36,12 @@ sink endpoints. The endpoints may be other pipelines or components.
 **DAI** Digital Audio Interface. A hardware audio serial interface used to 
 send audio data between hardware devices. e.g. I2S, Soundwire, PDM, HDA, HDMI.
 
-**Topology** A high level description of the network of the all the pipelines 
+**Topology** A high level description of the network of all the pipelines
 and components enumerated on the DSP. This is initially described in text format 
 before being compiled into a binary that firmware can process.
 
-**Module** Another name for component. Imples component is linked at runtime 
-rater than build time.
+**Module** Another name for component. Implies that component is linked at runtime
+rater than at build time.
 
 **Driver** Device driver used by the firmware to control hardware devices (like
 DMA, I2S) or SOF host OS device driver.
@@ -49,5 +49,5 @@ DMA, I2S) or SOF host OS device driver.
 **AAL** Architecture Abstraction Layer - Firmware abstraction layer used to
 abstract architecture specific code.
 
-**SRC** Sample Rate Convertor - Audio component used to convert sample rate
+**SRC** Sample Rate Converter - Audio component used to convert sample rate
 of a synchronous input stream to a synchronous output stream.


### PR DESCRIPTION
This patch fixes different misspellings i found when reading through
introduction page of developer guides section.

Signed-off-by: Mohana Datta Yelugoti <ymdatta.work@gmail.com>