### PR TITLE
getting_started: replace sof-mach-driver-defconfig to mach-driver-defconfig

### DIFF
--- a/getting_started/build-guide/build-from-scratch.rst
+++ b/getting_started/build-guide/build-from-scratch.rst
@@ -444,7 +444,7 @@ dev branch firmware and topology.
       git checkout topic/sof-dev
       make defconfig
       git clone https://github.com/thesofproject/kconfig
-      scripts/kconfig/merge_config.sh .config ./kconfig/base-defconfig ./kconfig/sof-defconfig  ./kconfig/sof-mach-driver-defconfig ./kconfig/hdaudio-codecs-defconfig
+      scripts/kconfig/merge_config.sh .config ./kconfig/base-defconfig ./kconfig/sof-defconfig  ./kconfig/mach-driver-defconfig ./kconfig/hdaudio-codecs-defconfig
       (optional) make menuconfig
 
    Select SOF driver support and disable SST drivers.


### PR DESCRIPTION
After change readme align with file names in kconfig repo.