### PR TITLE
conf: switch breathe to import into cpp domain

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -191,6 +191,3 @@ breathe_projects = {
 }
 breathe_default_project = "SOF Project"
 breathe_default_members = ('members', 'undoc-members', 'content-only')
-breathe_domain_by_extension = {
-   "h" : "c",
-}


### PR DESCRIPTION
Cpp domain provides much better formatting in Sphinx.
Initialized enum items are correctly displayed, pointer
to functions typedef-ed in place also works fine.

Other projects also tend to use cpp domain for import
from C headers.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>