### PR TITLE
substitutions.txt: add missing |JSL|

### DIFF
--- a/substitutions.txt
+++ b/substitutions.txt
@@ -10,6 +10,7 @@
 .. |APL| replace:: Apollo Lake
 .. |CNL| replace:: Cannon Lake
 .. |ICL| replace:: Ice Lake
+.. |JSL| replace:: Jasper Lake
 .. |TSC| replace:: Technical Steering Committee
 
 .. These are replacement strings for non-ASCII characters used within the project


### PR DESCRIPTION
Fixes commit f4ada42ce36c ("getting_started: Add build documenation for
ICL and JSL+") that added four "WARNING: Undefined substitution
referenced: JSL" and for literal "|JSL|" instances on
https://thesofproject.github.io/latest/getting_started/build-guide/build-from-scratch.html,
example:

>  Current target Intel platforms include: Bay Trail, Cherry Trail,
>  Haswell, Broadwell, Apollo Lake, Cannon Lake, Ice Lake and |JSL|.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>