### PR TITLE
build-from-scratch: add HTML links to source code thanks to extlinks

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -30,7 +30,10 @@ sys.path.insert(0, os.path.abspath('.'))
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['breathe', 'sphinx.ext.graphviz', 'sphinxcontrib.plantuml','sphinx.ext.todo']
+extensions = ['breathe', 'sphinx.ext.graphviz', 'sphinxcontrib.plantuml',
+              'sphinx.ext.todo', 'sphinx.ext.extlinks',
+]
+
 
 graphviz_output_format='svg'
 graphviz_dot_args=[
@@ -154,6 +157,13 @@ html_favicon = 'images/sof-favicon-16x16.png'
 numfig = True
 #numfig_secnum_depth = (2)
 numfig_format = {'figure': 'Figure %s', 'table': 'Table %s', 'code-block': 'Code Block %s'}
+
+extlinks = {
+    'git-sof-master':
+    ('https://github.com/thesofproject/sof/tree/master/%s', ""),
+    'git-alsa':
+    ('https://git.alsa-project.org/?p=%s.git', ""),
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/getting_started/build-guide/build-from-scratch.rst
+++ b/getting_started/build-guide/build-from-scratch.rst
@@ -78,8 +78,8 @@ sources. Refer to this short guide: https://cmake.org/install/
 Build alsa-lib and alsa-utils
 -----------------------------
 
-This project requires some new features in alsa-lib and alsa-utils, so build
-the newest ALSA from source code.
+This project requires some new features in :git-alsa:`alsa-lib` and
+:git-alsa:`alsa-utils`, so build the newest ALSA from source code.
 
 .. warning::
 
@@ -306,8 +306,9 @@ After the SOF environment is set up, clone the *sof* repo.
 One-step rebuild from scratch
 -----------------------------
 
-To rebuild |SOF| in just one step, use the following script after
-setting up the environment.
+To rebuild |SOF| in just one step, use
+:git-sof-master:`scripts/xtensa-build-all.sh` after setting up the
+environment.
 
 Build the firmware for all platforms.
 
@@ -498,10 +499,17 @@ Step 4 Build topology and tools
 One-step rebuild from scratch
 -----------------------------
 
+Without any argument :git-sof-master:`scripts/build-tools.sh` rebuilds
+only the minimum subset of :git-sof-master:`tools/`.
+
 .. code-block:: bash
 
    cd ~/work/sof/sof/
    ./scripts/build-tools.sh
+   ./scripts/build-tools.sh -h
+   usage: ./scripts/build-tools.sh [-t|-f]
+       [-t] Build test topologies
+       [-f] Build fuzzer"
 
 Incremental build
 -----------------


### PR DESCRIPTION
Start small with build scripts/ and ALSA repos, can easily be expanded
later if everything goes well.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>