### PR TITLE
Travis: switch sof/doc sub-build to Ninja

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,14 @@ python:
 
 before_install:
     - sudo apt-get update -qq
-    - sudo apt-get install doxygen make default-jre graphviz cmake
+    - sudo apt-get install doxygen make default-jre graphviz cmake ninja-build
 
 install:
     - pip install -r scripts/requirements.txt
 
 script:
-    - cd .. && git clone https://github.com/thesofproject/sof.git && cd sof/doc && cmake . && make doc && cd - && cd sof-docs
+    - pushd .. && git clone https://github.com/thesofproject/sof.git && pushd sof/doc && cmake -GNinja .
+    - popd && popd
     - make html
     - ls _build
 


### PR DESCRIPTION
Since commit a97756ab4307 was merged, Travis shows the following harmless but
misleading message:
```
 # To build doxygen APIs too run this first:
 #   cmake -GNinja -S ../sof/doc -B ../sof/doc
```
Example: https://travis-ci.org/github/thesofproject/sof-docs/builds/670800271

That's because the sof-docs documentation and sof-docs/Makefile now
expect a sof/doc/ninja.build. So switch sof-docs/.travis.yml away from
Make and to ninja.

In the future we'll probably want cmake -S sof/doc to use a separate
-B build directory. One thing at a time.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>