### PR TITLE
comp: tutorial: replace cpp:struct: with cpp:class:

### DIFF
--- a/developer_guides/firmware/component-tutorial/tut-i-basic-fw-code.rst
+++ b/developer_guides/firmware/component-tutorial/tut-i-basic-fw-code.rst
@@ -304,14 +304,15 @@ Signal Processing Function ``amp_copy``
 This first version of the processing function simply copies input samples to
 output and shows how to:
 
-* Use :cpp:struct:`comp_copy_limits` and :cpp:func:`comp_get_copy_limits_with_lock()`
+* Use :cpp:class:`comp_copy_limits`  and :cpp:func:`comp_get_copy_limits_with_lock()`
   to retrieve information about the number of samples to be processed.
 
 * Refresh the local data cache with :cpp:func:`buffer_invalidate()` in case
   the input data is being provided to the source buffer by a component
   running on another core.
 
-* Iterate over the frames, channels, and samples using the :cpp:struct:`comp_copy_limits` descriptor.
+* Iterate over the frames, channels, and samples using the
+  :cpp:class:`comp_copy_limits` descriptor.
 
 * Read/write from/to the circular buffers. This implementation assumes both
   input and output are signed 16-bit samples; therefore,


### PR DESCRIPTION
I tested most sphinx versions between 2.0.0 (when cpp:struct: was
introduced) and version 2.3.1 and `cpp:struct:` crashes them all with
the same traceback below. I don't know why but considering 2.4.0 was
released only in late 2019, let's just avoid the issue and use the older
`cpp:class:` instead. This also avoids bumping the sphinx version
in scripts/requirements.

For information I used doxygen version 1.8.15 and my generated file
`doc/doxygen/xml/structcomp__copy__limits.xml` has this line near the top:
`<compounddef id="structcomp__copy__limits" kind="struct" language="C++"
prot="public">`

The world "class" is nowhere in that generated file.

Fixes: e609daf988e2 ("comp: tutorial: update part I)

References:

 http://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#cross-referencing
 https://pypi.org/project/Sphinx/#history

Traceback:
```
Type is struct, declType is class

Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/sphinx/cmd/build.py", line 284, in build_main
    app.build(args.force_all, filenames)
  File "/usr/lib/python3.7/site-packages/sphinx/application.py", line 345, in build
    self.builder.build_update()
  File "/usr/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 319, in build_update
    len(to_build))
  File "/usr/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 382, in build
    self.write(docnames, list(updated_docnames), method)
  File "/usr/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 560, in write
    nproc=self.app.parallel - 1)
  File "/usr/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 586, in _write_parallel
    doctree = self.env.get_and_resolve_doctree(firstname, self)
  File "/usr/lib/python3.7/site-packages/sphinx/environment/__init__.py", line 554, in get_and_resolve_doctree
    self.apply_post_transforms(doctree, docname)
  File "/usr/lib/python3.7/site-packages/sphinx/environment/__init__.py", line 601, in apply_post_transforms
    transformer.apply_transforms()
  File "/usr/lib/python3.7/site-packages/sphinx/transforms/__init__.py", line 90, in apply_transforms
    super().apply_transforms()
  File "/usr/lib/python3.7/site-packages/docutils/transforms/__init__.py", line 172, in apply_transforms
    transform.apply(**kwargs)
  File "/usr/lib/python3.7/site-packages/sphinx/transforms/post_transforms/__init__.py", line 45, in apply
    self.run(**kwargs)
  File "/usr/lib/python3.7/site-packages/sphinx/transforms/post_transforms/__init__.py", line 92, in run
    typ, target, node, contnode)
  File "/usr/lib/python3.7/site-packages/sphinx/domains/cpp.py", line 7277, in resolve_xref
    target, node, contnode)[0]
  File "/usr/lib/python3.7/site-packages/sphinx/domains/cpp.py", line 7217, in _resolve_xref_inner
    if not checkType():
  File "/usr/lib/python3.7/site-packages/sphinx/domains/cpp.py", line 7216, in checkType
    assert False
AssertionError
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>