### PR TITLE
demux: there's no "m4" Python syntax highlighter

### DIFF
--- a/algos/demux/demux.rst
+++ b/algos/demux/demux.rst
@@ -59,7 +59,7 @@ hexadecimal or integer values. SOF topology m4 macros have helpers to
 The following example from pipe-volume-demux-playback.m4 shows how to define
 2 routing matrices and a demux component:
 
-.. code-block:: m4
+.. code-block::
 
 		# pipeline_id, channels, matrix_rows
 		define(matrix1, `ROUTE_MATRIX(PIPELINE_ID, 2,
@@ -118,7 +118,7 @@ python tool:
 
 It produces the following output:
 
-.. code-block:: m4
+.. code-block::
 
 		sof m4 and ALSA conf format:
 		`       bytes "0x53,0x4f,0x46,0x00,0x12,0x00,0x00,0x00,0x3c,'


### PR DESCRIPTION
```diff
-.. code-block:: m4
+.. code-block::
```
... to get rid of the following warning:
```
  sof-docs/algos/demux/demux.rst:121:
    WARNING: Pygments lexer name 'm4' is not known
```
I looked at https://pygments.org/docs/lexers and tried a couple of
alternatives. They all either:
 - fail to parse m4's unique `string' syntax and render ugly, or
 - are too simplistic and render everything the same except comments;
   until the doc changes and then they break mysteriously.

Keep it simple.

Fixes: 6af9f4448b7d5 ("add mux/demux documentation")

Signed-off-by: Marc Herbert <marc.herbert@intel.com>