### PR TITLE
api: add new sof_dma_copy_func subgroup to add dma_copy() func back

### DIFF
--- a/api/dma-drivers-api.rst
+++ b/api/dma-drivers-api.rst
@@ -5,3 +5,15 @@ DMA Drivers API
 
 .. doxygengroup:: sof_dma_drivers
    :project: SOF Project
+
+..
+   Keep 'sof_dma_copy_func' after 'sof_dma_drivers' so most dma_copy
+   links (correctly) point to the struct and not to the func. This also
+   avoids the 'WARNING: Duplicate declaration, dma_copy' for some
+   unclear reason.
+
+.. doxygengroup:: sof_dma_copy_func
+   :project: SOF Project
+
+This function is listed separately to solve a name clash with the struct
+dma_copy {} above.


### PR DESCRIPTION
sof commit bf6d97c76a5a / https://github.com/thesofproject/sof/pull/2773 moved dma_copy() to a different subgroup to
solve the name clash with struct dma_copy{} which made the function
temporarily disappear from sphinx' output.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>