### PR TITLE
comp: uuid: Update UUID to runtime version for components

### DIFF
--- a/developer_guides/firmware/component-tutorial/tut-i-basic-fw-code.rst
+++ b/developer_guides/firmware/component-tutorial/tut-i-basic-fw-code.rst
@@ -57,7 +57,7 @@ Add the following declaration at the beginning of the source file:
 
 .. code-block:: c
 
-   DECLARE_SOF_UUID("amp", amp_uuid, 0x1d501197, 0xda27, 0x4697,
+   DECLARE_SOF_RT_UUID("amp", amp_uuid, 0x1d501197, 0xda27, 0x4697,
                     0x80, 0xc8, 0x4e, 0x69, 0x4d, 0x36, 0x00, 0xa0);
 
    DECLARE_TR_CTX(amp_tr, SOF_UUID(amp_uuid), LOG_LEVEL_INFO);
@@ -95,7 +95,7 @@ devices, and their drivers, refer to :ref:`apps-component-overview` and
 
    struct comp_driver comp_amp = {
            .type = SOF_COMP_AMP,
-           .uid = SOF_UUID(amp_uuid),
+           .uid = SOF_RT_UUID(amp_uuid),
            .tctx = &amp_tr,
            .ops = {
                    .create = amp_new,
@@ -123,7 +123,7 @@ devices, and their drivers, refer to :ref:`apps-component-overview` and
 
 Note that the ``type`` used for the component driver is set to the
 ``SOF_COMP_AMP`` which is declared earlier. The ``uid`` used for logging is
-initialized by the ``SOF_UUID(amp_uuid)``, where ``amp_uuid`` is declared at
+initialized by the ``SOF_RT_UUID(amp_uuid)``, where ``amp_uuid`` is declared at
 the beginning of the source file. The trace context ``amp_tr`` is associated
 with the driver object as well.
 

--- a/developer_guides/firmware/components/component-overview.rst
+++ b/developer_guides/firmware/components/component-overview.rst
@@ -31,13 +31,13 @@ expected to replace the ``type`` in these parts as well.
 
 The UUID entry declared in the FW code contains the identifier value as well
 as the object which is the component name in this case. Both are
-provided as the arguments to the ``DECLARE_SOF_UUID()`` macro. For example
+provided as the arguments to the ``DECLARE_SOF_RT_UUID()`` macro. For example
 the **volume** component provides the following declaration:
 
 .. code-block:: c
 
    /* b77e677e-5ff4-4188-af14-fba8bdbf8682 */
-   DECLARE_SOF_UUID("volume", volume_uuid, 0xb77e677e, 0x5ff4, 0x4188,
+   DECLARE_SOF_RT_UUID("volume", volume_uuid, 0xb77e677e, 0x5ff4, 0x4188,
                     0xaf, 0x14, 0xfb, 0xa8, 0xbd, 0xbf, 0x86, 0x82);
 
 Note how the ``af14`` 16bit segment is split into two bytes at the beginning of
@@ -52,7 +52,7 @@ declared UUID with the volume of the component driver:
 
    static const struct comp_driver comp_volume = {
            .type = SOF_COMP_VOLUME,
-           .uid  = SOF_UUID(volume_uuid),
+           .uid  = SOF_RT_UUID(volume_uuid),
            ...
    };
 


### PR DESCRIPTION
In new version, each component should have runtime accessible
UUID value, to allow topology build by uuid value instead of
component type.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>

related with https://github.com/thesofproject/sof/pull/3010