### PR TITLE
contribute: docbuild: Update the links to repositories

### DIFF
--- a/contribute/process/docbuild.rst
+++ b/contribute/process/docbuild.rst
@@ -315,8 +315,8 @@ Python packages in the virtualized environment:
 .. code-block:: bash
 
 	pip install sphinx
-	git clone https://github.com/thesofprojects/sof
-	git clone https://github.com/thesofprojects/sof-docs
+	git clone https://github.com/thesofproject/sof
+	git clone https://github.com/thesofproject/sof-docs
 	cd sof-docs/
 	pip install -r scripts/requirements.txt
 


### PR DESCRIPTION
The current github repository link is incorrect, update the file
to point to correct repository.

Signed-off-by: Mohana Datta Yelugoti <ymdatta.work@gmail.com>