### PR TITLE
logger: Update help message with -h flag

### DIFF
--- a/developer_guides/debugability/logger/index.rst
+++ b/developer_guides/debugability/logger/index.rst
@@ -38,6 +38,7 @@ Usage sof-logger <option(s)> <file(s)>
 -r		Less formatted output for chained log processors
 -L		Hide log location in source code
 -f precision	Set timestamp precision
+-g		Hide timestamp
 -d		Dump ldc information
 
 Examples:


### PR DESCRIPTION
After removing timestamps it is possible to compare output logs
with tools like diff or similar. Moreover then output logs are
in more compact form.

Signed-off-by: Karol Trzcinski <karolx.trzcinski@linux.intel.com>

Related with https://github.com/thesofproject/sof/pull/3087