### PR TITLE
doc: do not hide doxygen group documention

### DIFF
--- a/static/sof-custom.css
+++ b/static/sof-custom.css
@@ -77,7 +77,7 @@ th,td {
 }
 
 /* tweak for doxygen-generated API headings (for RTD theme) */
-.rst-content dl.group>dt, .rst-content dl.group>dd>p {
+.rst-content dl.group>dt {
    display:none !important;
 }
 .rst-content dl.group {


### PR DESCRIPTION
Adjust the CSS rules to not hide API group documentation such
as the text we have in include/ipc/header.h. In Breathe output
for doxygen groups, <dt> tags are used to show the group name.
These do not look nice and do not relay any useful info, so
better to keep them hidden still.

Co-developed-by: Marcin Maka <marcin.maka@linux.intel.com>
Co-developed-by: Kevin Putnam <kevin.putnam@intel.com>
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>