### PR TITLE
debugability: sof-ri-info: update examples

### DIFF
--- a/developer_guides/debugability/ri-info/output_full_bytes.txt
+++ b/developer_guides/debugability/ri-info/output_full_bytes.txt
@@ -1,73 +1,53 @@
-$ python ./sof_ri_info.py --no_colors --full_bytes sof-cnl-v1.4.2.ri
-SOF Binary sof-cnl-v1.4.2.ri size 0x46000
+$ python ./sof_ri_info.py --no_colors --full_bytes sof-cnl.ri
+SOF Binary sof-cnl.ri size 0x5b000
 
 
-  CSE Manifest ver 0x101 checksum 0x42 partition name ADSP
+  CSE Manifest ver 0x101 checksum 0xf1 partition name ADSP
 
-    ADSP.man     (CSS Manifest) type 0x4 ver 0x10000 date 2020/01/22
+    ADSP.man (CSS Manifest) type 0x4 ver 0x10000 date 2020/07/16
       Rsvd0 0x0
       Modulus size (dwords) 64
-        85 00 e1 68 aa eb d2 07 1b 7c 5e ed d6 e7 e5 f9 c1 0e 47 d4 4c ab 8c f0 e8 ee 8b 40 36 35 58 8f f4 6f fc fd 0f dd 55 8b 45 8c f0 47 dc b4 ac 21 3b 4b 20 e6 81 b3 cc 90 d4 5e f1 a4 9b 68 52 c8 f1 2d f9 c4 77 c6 4d a9 90 c7 10 fd 43 c8 4b 6b 23 5e 92 f5 8f ac d5 7d 60 27 36 7c 21 4e 21 99 de cb c0 45 f3 04 22 b8 7d 16 68 40 f9 5c f0 b9 7e 8c 05 b6 fc 28 bb 3d d8 ff b6 a4 d4 54 27 3b 1a 42 4e f5 a6 a8
-5e 44 e2 9e ed 68 6a 27 60 13 8d 2f 27 70 cd 57 c9 18 a3 b0 30 a1 f4 e6 32 12 89 2a af 40 a5 fd 52 f1 aa 8a a4 ef 20 3d 10 a3 70 f2 39 c5 05 99 22 10 81 83 6e 45 a4 f3 5a 9d 6a b8 88 fe 69 40 d1 b1 cb 2a db 28 05 de 54 bf 3d 86 5f 39 8b c1 f4 af 00 61 86 01 fa 22 ac f6 2c a4 17 6a a7 d8 0a 8c 9f bf 1f 62 b2 2e 68 52 3f 82 8f e5 28 4d db b5 5a 96 28 27 19 af 43 b9
+        85 00 e1 68 aa eb d2 07 1b 7c 5e ed d6 e7 e5 f9 c1 0e 47 d4 4c ab 8c f0 e8 ee 8b 40 36 35 58 8f f4 6f fc fd 0f dd 55 8b 45 8c f0 47 dc b4 ac 21 3b 4b 20 e6 81 b3 cc 90 d4 5e f1 a4 9b 68 52 c8 f1 2d f9 c4 77 c6 4d a9 90 c7 10 fd 43 c8 4b 6b 23 5e 92 f5 8f ac d5 7d 60 27 36 7c 21 4e 21 99 de cb c0 45 f3 04 22 b8 7d 16 68 40 f9 5c f0 b9 7e 8c 05 b6 fc 28 bb 3d d8 ff b6 a4 d4 54 27 3b 1a 42 4e f5 a6 a8 5e 44 e2 9e ed 68 6a 27 60 13 8d 2f 27 70 cd 57 c9 18 a3 b0 30 a1 f4 e6 32 12 89 2a af 40 a5 fd 52 f1 aa 8a a4 ef 20 3d 10 a3 70 f2 39 c5 05 99 22 10 81 83 6e 45 a4 f3 5a 9d 6a b8 88 fe 69 40 d1 b1 cb 2a db 28 05 de 54 bf 3d 86 5f 39 8b c1 f4 af 00 61 86 01 fa 22 ac f6 2c a4 17 6a a7 d8 0a 8c 9f bf 1f 62 b2 2e 68 52 3f 82 8f e5 28 4d db b5 5a 96 28 27 19 af 43 b9
       Exponent size (dwords) 1
         01 00 01 00
       Signature
-        4a d3 c8 3e a1 e2 19 63 a2 ea 51 aa 60 42 98 f6 1b bf 41 a9 df de d7 4f 56 b7 90 d3 4f 70 db a9 3a 3d 30 71 27 e9 72 0b 6d 50 a4 76 6b 0b dc 07 7b ac 91 d3 d4 d0 9e da ee a0 9b c2 5b 01 e0 bc 3f 5c 36 33 f5 d2 a1 9d b1 03 44 fb 5d 5d ae 82 63 51 80 31 15 52 36 85 fd e4 40 d2 0a b1 47 c1 d9 fa 33 f2 97 76 4a 1e 64 19 78 bf b2 df be 9b 61 14 f1 64 c9 53 e4 40 a1 77 2b 59 7b bb 00 80 42 aa 87 d9 17 a9
-d2 06 d5 27 52 8a 6d 52 f3 59 2b d6 bc 60 c9 98 85 73 fe d3 28 00 5b 91 26 3a de 2f e6 a4 d3 6f 14 34 14 d8 b2 8d 06 cb 26 df 97 d7 6d f0 e1 83 bf 66 6d 98 37 fb 50 fa b4 1d b5 d6 62 bc 81 f4 09 53 31 c6 1b 7e 47 9f 4a fd d8 0b e8 9e a2 fa 57 ee 6b a9 c5 b1 d0 03 c7 3c 6a 9a 71 31 2b be 44 4c 60 28 e4 d9 79 71 ef 66 85 ec 0a 30 29 10 7d 33 78 2b 91 5c 0d 7f f5 91
+        86 67 47 b1 d5 00 7a e9 11 61 47 3a aa fe d1 df a2 9a 52 56 d6 fc 1a 4c 01 2d a0 cf 92 2e 14 3e 0b 60 29 4e 1e 42 f5 29 ba a2 57 da 73 54 f1 be 75 63 cb 41 c5 8f 8a ec 98 5b 49 61 19 c3 a9 5b e6 d6 6b 72 2e 8c 5c 30 af f6 9b 33 50 6f 3b 44 cc 82 90 a6 bc 09 38 75 99 d8 81 e0 42 e2 9d bb ad 6c 8a 0c e9 bb 06 d3 c7 d1 25 82 24 07 b8 10 3d 53 ca 3b 1d 82 f3 55 97 39 1f ad 25 7a dc 1b 8d 85 bb 54 6f 15 3f ed e0 a6 3e 18 20 d9 15 69 0e da b7 b5 f3 d7 8c 56 ad 8b be 7a dc 2f ba 33 59 a0 95 f4 b3 42 db c5 77 4a d0 f3 3c d0 39 47 54 0e 58 87 6b 50 b0 22 6d 78 bd d8 62 7b 04 24 95 e6 00 49 72 c6 bc fb 13 03 1c 3e 95 e2 51 da 83 30 6d 49 19 76 a2 7b 28 68 d9 97 32 85 c3 e7 f6 b4 f1 13 a6 c2 27 a1 a2 fc c0 9b a9 1a 62 9b dd 3f c5 81 6a 70 a5 3f f5 30 10 9c 56 16 f1 90
 
       Plat Fw Auth Extension name ADSP vcn 0x0 bitmap 00 00 00 00 08 00 00 00 00 00 00 00 00 00 00 00 svn 0x0
 
-      Other Extension type 0x50534441 length 0x46000
+      Other Extension type 0x50534441 length 0x5b000
 
-    cavs0015.met (ADSP Metadata File Extension) ver 0x0 base offset 0x2000 limit offset 0x47b80
+    cavs0015.met (ADSP Metadata File Extension) ver 0x0 base offset 0x2000 limit offset 0x5cb80
       IMR type 0x3
       Attributes
         00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 
-    cavs0015     (ADSP Manifest) name ADSPFW build ver 1.4.0.1 feature mask 0x1ff image flags 0x0
-      HW buffers base address 0x0 length 0x0
-      Load offset 0x30000
+    cavs0015
 
-      Module Entry
-        sig                 $AME
-        mod_name            BRNGUP
-        uuid                2b79e4f3-4675-f649-89df-3bc194a91aeb
-        type                0x21 ( loadable LL )
-        hash                9d e2 3d c4 53 36 b9 26 8c 33 6b 32 92 36 9a 14 6f f1 74 9a 9c 8a 09 70 f5 0b 4a 5c 04 a0 96 b1
-        entry_point         0xb0038000
-        cfg_offset          0
-        cfg_count           0
-        affinity_mask       0x3
-        instance_max_count  1
-        instance_stack_size 0x1
-        seg_0 flags         0x1001f ( contents alloc load readonly code type=0 pages=1 )
-        seg_0 v_base_addr   0xb0038000
-        seg_0 file_offset   0x8000
-        seg_1 flags         0x1012f ( contents alloc load readonly data type=1 pages=1 )
-        seg_1 v_base_addr   0xb0039000
-        seg_1 file_offset   0x9000
-        seg_2 flags         0xf00 ( type=15 pages=0 )
-        seg_2 v_base_addr   0x0
-        seg_2 file_offset   0x0
+  cavs0015 (ADSP Manifest) name ADSPFW build ver 1.5.0.1 feature mask 0x1ff image flags 0x0
+    HW buffers base address 0x0 length 0x0
+    Load offset 0x30000
 
-      Module Entry
-        sig                 $AME
-        mod_name            BASEFW
-        uuid                0e398c32-5ade-ba4b-93b1-c50432280ee4
-        type                0x21 ( loadable LL )
-        hash                61 73 4b 78 b1 1e 49 5a ea e6 14 e8 05 e9 80 4d a9 df 8c 69 ad a5 a4 42 11 bb fb ae af ba 31 f8
-        entry_point         0xbe00c400
-        cfg_offset          0
-        cfg_count           0
-        affinity_mask       0x3
-        instance_max_count  1
-        instance_stack_size 0x1
-        seg_0 flags         0x23001f ( contents alloc load readonly code type=0 pages=35 )
-        seg_0 v_base_addr   0xbe00c000
-        seg_0 file_offset   0xa000
-        seg_1 flags         0x19012f ( contents alloc load readonly data type=1 pages=25 )
-        seg_1 v_base_addr   0xbe02f000
-        seg_1 file_offset   0x2d000
-        seg_2 flags         0xb80202 ( alloc type=2 pages=184 )
-        seg_2 v_base_addr   0xbe048000
-        seg_2 file_offset   0x0
+    BRNGUP    2b79e4f3-4675-f649-89df-3bc194a91aeb
+      entry point 0xb0038000 type 0x21 ( loadable LL )
+      cfg offset 0 count 0 affinity 0x3 instance max count 1 stack size 0x1
+      .text   0xb0038000 file offset 0x8000 flags 0x1001f ( contents alloc load readonly code type=0 pages=1 )
+      .rodata 0xb0039000 file offset 0x9000 flags 0x1012f ( contents alloc load readonly data type=1 pages=1 )
+      .bss    0x0 file offset 0x0 flags 0xf00 ( type=15 pages=0 )
+
+    BASEFW    0e398c32-5ade-ba4b-93b1-c50432280ee4
+      entry point 0xbe00c400 type 0x21 ( loadable LL )
+      cfg offset 0 count 0 affinity 0x3 instance max count 1 stack size 0x1
+      .text   0xbe00c000 file offset 0xa000 flags 0x2d001f ( contents alloc load readonly code type=0 pages=45 )
+      .rodata 0xbe039000 file offset 0x37000 flags 0x24012f ( contents alloc load readonly data type=1 pages=36 )
+      .bss    0xbe05d000 file offset 0x0 flags 0xa30202 ( alloc type=2 pages=163 )
+
+Intel Cannonlake
+  imr                                 0xb0000000 (8192 + 136579200  0.01% used)
+    BRNGUP.text                         0xb0038000 (4096)
+    BRNGUP.rodata                       0xb0039000 (4096)
+  l2 hpsram                           0xbe000000 (999424 + 2146304  31.77% used)
+    BASEFW.text                         0xbe00c000 (184320)
+    BASEFW.rodata                       0xbe039000 (147456)
+    BASEFW.bss                          0xbe05d000 (667648)
+  l2 lpsram                           0xbe800000 (65536)

--- a/developer_guides/debugability/ri-info/output_headers.txt
+++ b/developer_guides/debugability/ri-info/output_headers.txt
@@ -1,27 +1,39 @@
-$ python ./sof_ri_info.py --no_colors --headers sof-cnl-v1.4.2.ri
-SOF Binary sof-cnl-v1.4.2.ri size 0x46000
+$ python ./sof_ri_info.py --no_colors --headers sof-cnl.ri
+SOF Binary sof-cnl.ri size 0x5b000
 
 
-  CSE Manifest ver 0x101 checksum 0x42 partition name ADSP
+  CSE Manifest ver 0x101 checksum 0xf1 partition name ADSP
 
-    ADSP.man     (CSS Manifest) type 0x4 ver 0x10000 date 2020/01/22
+    ADSP.man (CSS Manifest) type 0x4 ver 0x10000 date 2020/07/16
       Rsvd0 0x0
       Modulus size (dwords) 64
         85 00 e1 68 aa eb d2 07 ... 5a 96 28 27 19 af 43 b9 (Community key)
       Exponent size (dwords) 1
         01 00 01 00
       Signature
-        4a d3 c8 3e a1 e2 19 63 ... 78 2b 91 5c 0d 7f f5 91
+        86 67 47 b1 d5 00 7a e9 ... f5 30 10 9c 56 16 f1 90
 
       Plat Fw Auth Extension name ADSP vcn 0x0 bitmap 00 00 00 00 08 00 00 00 00 00 00 00 00 00 00 00 svn 0x0
 
-      Other Extension type 0x50534441 length 0x46000
+      Other Extension type 0x50534441 length 0x5b000
 
-    cavs0015.met (ADSP Metadata File Extension) ver 0x0 base offset 0x2000 limit offset 0x47b80
+    cavs0015.met (ADSP Metadata File Extension) ver 0x0 base offset 0x2000 limit offset 0x5cb80
       IMR type 0x3
       Attributes
         00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 
-    cavs0015     (ADSP Manifest) name ADSPFW build ver 1.4.0.1 feature mask 0x1ff image flags 0x0
-      HW buffers base address 0x0 length 0x0
-      Load offset 0x30000
+    cavs0015
+
+  cavs0015 (ADSP Manifest) name ADSPFW build ver 1.5.0.1 feature mask 0x1ff image flags 0x0
+    HW buffers base address 0x0 length 0x0
+    Load offset 0x30000
+
+Intel Cannonlake
+  imr                                 0xb0000000 (8192 + 136579200  0.01% used)
+    BRNGUP.text                         0xb0038000 (4096)
+    BRNGUP.rodata                       0xb0039000 (4096)
+  l2 hpsram                           0xbe000000 (999424 + 2146304  31.77% used)
+    BASEFW.text                         0xbe00c000 (184320)
+    BASEFW.rodata                       0xbe039000 (147456)
+    BASEFW.bss                          0xbe05d000 (667648)
+  l2 lpsram                           0xbe800000 (65536)

--- a/developer_guides/debugability/ri-info/output_verbose.txt
+++ b/developer_guides/debugability/ri-info/output_verbose.txt
@@ -1,80 +1,76 @@
-$ python ./sof_ri_info.py --no_colors -v sof-cnl-v1.4.2.ri
-Reading SOF ri image sof-cnl-v1.4.2.ri
-File size 0x46000 (286720)
+$ python ./sof_ri_info.py --no_colors -v sof-cnl.ri
+Reading SOF ri image sof-cnl.ri
+File size 0x5b000 (372736)
+0x0     Looking for Extended Manifest
 0x0     info: Extended Manifest not found (sig = $CPD)
+0x0     Looking for CSE Manifest
 0x0     CSE Manifest ($CPD)
+0x8     # of entries 3
+0x10    Looking for CSE Manifest entry
+0x28    CSE Entry name ADSP.man length 888
+0x58    Parsing CSS Manifest
 0x58    CSS Manifest type 4
+0x58    Parsing CSS Manifest type 4
+0x2dc   Parsing CSS Manifest extensions end 0x3d0
+0x2e0   Reading extension type 0xf
+0x350   Reading extension type 0x50534441
+0x28    Looking for CSE Manifest entry
+0x40    CSE Entry name cavs0015.met length 96
+0x40    Looking for CSE Manifest entry
+0x58    CSE Entry name cavs0015 length 371584
 0x2000  ADSP Manifest ($AM1)
 0x2034  Module Entry signature found ($AME)
 0x20a8  Module Entry signature found ($AME)
 Parsing finished
-SOF Binary sof-cnl-v1.4.2.ri size 0x46000
+SOF Binary sof-cnl.ri size 0x5b000
 
 
-  CSE Manifest ver 0x101 checksum 0x42 partition name ADSP
+  CSE Manifest ver 0x101 checksum 0xf1 partition name ADSP
 
-    ADSP.man     (CSS Manifest) type 0x4 ver 0x10000 date 2020/01/22
+    ADSP.man (CSS Manifest) type 0x4 ver 0x10000 date 2020/07/16
       Rsvd0 0x0
       Modulus size (dwords) 64
         85 00 e1 68 aa eb d2 07 ... 5a 96 28 27 19 af 43 b9 (Community key)
       Exponent size (dwords) 1
         01 00 01 00
       Signature
-        4a d3 c8 3e a1 e2 19 63 ... 78 2b 91 5c 0d 7f f5 91
+        86 67 47 b1 d5 00 7a e9 ... f5 30 10 9c 56 16 f1 90
 
       Plat Fw Auth Extension name ADSP vcn 0x0 bitmap 00 00 00 00 08 00 00 00 00 00 00 00 00 00 00 00 svn 0x0
 
-      Other Extension type 0x50534441 length 0x46000
+      Other Extension type 0x50534441 length 0x5b000
 
-    cavs0015.met (ADSP Metadata File Extension) ver 0x0 base offset 0x2000 limit offset 0x47b80
+    cavs0015.met (ADSP Metadata File Extension) ver 0x0 base offset 0x2000 limit offset 0x5cb80
       IMR type 0x3
       Attributes
         00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 
-    cavs0015     (ADSP Manifest) name ADSPFW build ver 1.4.0.1 feature mask 0x1ff image flags 0x0
-      HW buffers base address 0x0 length 0x0
-      Load offset 0x30000
+    cavs0015
 
-      Module Entry
-        sig                 $AME
-        mod_name            BRNGUP
-        uuid                2b79e4f3-4675-f649-89df-3bc194a91aeb
-        type                0x21 ( loadable LL )
-        hash                9d e2 3d c4 53 36 b9 26 ... f5 0b 4a 5c 04 a0 96 b1
-        entry_point         0xb0038000
-        cfg_offset          0
-        cfg_count           0
-        affinity_mask       0x3
-        instance_max_count  1
-        instance_stack_size 0x1
-        seg_0 flags         0x1001f ( contents alloc load readonly code type=0 pages=1 )
-        seg_0 v_base_addr   0xb0038000
-        seg_0 file_offset   0x8000
-        seg_1 flags         0x1012f ( contents alloc load readonly data type=1 pages=1 )
-        seg_1 v_base_addr   0xb0039000
-        seg_1 file_offset   0x9000
-        seg_2 flags         0xf00 ( type=15 pages=0 )
-        seg_2 v_base_addr   0x0
-        seg_2 file_offset   0x0
+  cavs0015 (ADSP Manifest) name ADSPFW build ver 1.5.0.1 feature mask 0x1ff image flags 0x0
+    HW buffers base address 0x0 length 0x0
+    Load offset 0x30000
 
-      Module Entry
-        sig                 $AME
-        mod_name            BASEFW
-        uuid                0e398c32-5ade-ba4b-93b1-c50432280ee4
-        type                0x21 ( loadable LL )
-        hash                61 73 4b 78 b1 1e 49 5a ... 11 bb fb ae af ba 31 f8
-        entry_point         0xbe00c400
-        cfg_offset          0
-        cfg_count           0
-        affinity_mask       0x3
-        instance_max_count  1
-        instance_stack_size 0x1
-        seg_0 flags         0x23001f ( contents alloc load readonly code type=0 pages=35 )
-        seg_0 v_base_addr   0xbe00c000
-        seg_0 file_offset   0xa000
-        seg_1 flags         0x19012f ( contents alloc load readonly data type=1 pages=25 )
-        seg_1 v_base_addr   0xbe02f000
-        seg_1 file_offset   0x2d000
-        seg_2 flags         0xb80202 ( alloc type=2 pages=184 )
-        seg_2 v_base_addr   0xbe048000
-        seg_2 file_offset   0x0
+    BRNGUP    2b79e4f3-4675-f649-89df-3bc194a91aeb
+      entry point 0xb0038000 type 0x21 ( loadable LL )
+      cfg offset 0 count 0 affinity 0x3 instance max count 1 stack size 0x1
+      .text   0xb0038000 file offset 0x8000 flags 0x1001f ( contents alloc load readonly code type=0 pages=1 )
+      .rodata 0xb0039000 file offset 0x9000 flags 0x1012f ( contents alloc load readonly data type=1 pages=1 )
+      .bss    0x0 file offset 0x0 flags 0xf00 ( type=15 pages=0 )
+
+    BASEFW    0e398c32-5ade-ba4b-93b1-c50432280ee4
+      entry point 0xbe00c400 type 0x21 ( loadable LL )
+      cfg offset 0 count 0 affinity 0x3 instance max count 1 stack size 0x1
+      .text   0xbe00c000 file offset 0xa000 flags 0x2d001f ( contents alloc load readonly code type=0 pages=45 )
+      .rodata 0xbe039000 file offset 0x37000 flags 0x24012f ( contents alloc load readonly data type=1 pages=36 )
+      .bss    0xbe05d000 file offset 0x0 flags 0xa30202 ( alloc type=2 pages=163 )
+
+Intel Cannonlake
+  imr                                 0xb0000000 (8192 + 136579200  0.01% used)
+    BRNGUP.text                         0xb0038000 (4096)
+    BRNGUP.rodata                       0xb0039000 (4096)
+  l2 hpsram                           0xbe000000 (999424 + 2146304  31.77% used)
+    BASEFW.text                         0xbe00c000 (184320)
+    BASEFW.rodata                       0xbe039000 (147456)
+    BASEFW.bss                          0xbe05d000 (667648)
+  l2 lpsram                           0xbe800000 (65536)


### PR DESCRIPTION
Update example output with content produced by the latest
version of sof-ri-info.
Format of module info was changed significantly and outdated
examples may confuse a reader.

Signed-off-by: Marcin Maka <marcin.maka@linux.intel.com>