### PR TITLE
Switch internal links to :ref: 

### DIFF
--- a/developer_guides/fuzzer/fuzzing.rst
+++ b/developer_guides/fuzzer/fuzzing.rst
@@ -6,8 +6,8 @@ Fuzzing in Docker
 Instructions
 ************
 
-#. Build a fuzzer in order to use it. Follow the instructions at `Build SOF
-   with docker: Step 4: Build Topology and Tools <https://thesofproject.github.io/latest/getting_started/build-guide/build-with-docker.html#build-topology-and-tools>`__.
+#. Build a fuzzer in order to use it. Follow the instructions at Build SOF
+   with docker, :ref:`docker-topology-tools`.
 
 #. Enter the Docker container:
 

--- a/developer_guides/linux_driver/architecture/sof_driver_arch.rst
+++ b/developer_guides/linux_driver/architecture/sof_driver_arch.rst
@@ -124,7 +124,13 @@ IPC messages are divided into several groups: global reply, topology, power mana
 PCM Driver
 **********
 
-The SOF PCM driver creates ALSA PCMs, DAPM, and kcontrols based on the `topology <https://thesofproject.github.io/latest/developer_guides/topology/topology.html>`_ data loaded at runtime. The PCM driver also allocates buffers for DMA and registers with runtime PM. It contains architecture- and platform-generic code. The PCM driver implements the low-level functions defined by the ALSA PCM middle layer in ``struct snd_pcm_ops``. These functions implement the platform-generic parts and invoke platform-specific ops to access the hardware.
+The SOF PCM driver creates ALSA PCMs, DAPM, and kcontrols based on the
+:ref:`topology` data loaded at runtime. The PCM driver also allocates
+buffers for DMA and registers with runtime PM. It contains architecture-
+and platform-generic code. The PCM driver implements the low-level
+functions defined by the ALSA PCM middle layer in ``struct
+snd_pcm_ops``. These functions implement the platform-generic parts and
+invoke platform-specific ops to access the hardware.
 
 When the machine driver is probed and the sound card is registered, the SOF PCM component driver gets probed when the dai links in the sound card are bound to the card. The SOF PCM component probe callback loads the topology file for the DUT. The SOF topology defines the audio processing pipelines, FE DAIs, and the BE DAI configuration for the BE dai links defined in the machine driver. Therefore, it is important to make sure that the DAI link IDs for the BE DAIs are identical in the topology and the machine driver. A mismatch in the DAI links ID will cause the sound card registration to fail.
 
@@ -343,4 +349,6 @@ Force IPC Position
 
 Sending position update IPC from the firmware to the host is a generic method to generate period interrupts to meet the requirement from the ALSA IRQ mode (e.g. ``snd_pcm_period_elapsed()``). On some HDA-integrated platforms (e.g. Intel SKL+ ones), this interrupt can be generated using the `HDA <https://www.intel.com/content/dam/www/public/us/en/documents/product-specifications/high-definition-audio-specification.pdf>`_ period IOC (interrupt on complete) and the real-time buffer pointers can be read back from the DPIB (DMA Pointer In Buffer). On these platforms, the position update IPC is only the fallback choice and is not used by default.
 
-In order to debug issues with IOC/DPIB, the force IPC position kernel debug config can be selected. On Intel SKL- platforms, the stream position update IPC is used whether or not this option is selected.
+In order to debug issues with IOC/DPIB, the force IPC position kernel
+debug config can be selected. On Intel SKL- platforms, the stream
+position update IPC is used whether or not this option is selected.

--- a/getting_started/build-guide/build-from-scratch.rst
+++ b/getting_started/build-guide/build-from-scratch.rst
@@ -147,6 +147,8 @@ Create or append to the ``LD_LIBRARY_PATH`` environment variable.
 
    export LD_LIBRARY_PATH="${SOF_WORKSPACE}"/alsa-lib/src/.libs:$LD_LIBRARY_PATH
 
+.. _build-toolchains-from-source:
+
 Step 2 Build toolchains from source
 ===================================
 

--- a/getting_started/build-guide/build-with-docker.rst
+++ b/getting_started/build-guide/build-with-docker.rst
@@ -158,6 +158,8 @@ your target machine's /lib/firmware/intel/sof folder.
 
    sof-apl.ri  sof-bdw.ri  sof-byt.ri  sof-cht.ri  sof-cnl.ri  sof-hsw.ri
 
+.. _docker-topology-tools:
+
 Build topology and tools
 ========================
 

--- a/introduction/index.rst
+++ b/introduction/index.rst
@@ -206,8 +206,8 @@ Which Xtensa toolchains does SOF currently support?
      documented in the getting started guide. These must be built from
      source. For instructions, refer to the following:
 
-     - `Build toolchains from source <https://thesofproject.github.io/latest/getting_started/build-guide/build-from-scratch.html#step-2-build-toolchains-from-source>`_
-       in the Getting Started Guide for building SOF from scratch
+     - :ref:`build-toolchains-from-source` in the Getting Started Guide
+       for building SOF from scratch
 
      - `Toolchains and embedded distributions <http://wiki.linux-xtensa.org/index.php/Toolchain_and_Embedded_Distributions>`_
 
@@ -215,7 +215,7 @@ Which Xtensa toolchains does SOF currently support?
      is proprietary but uses the open source GNU binutils. XCC must be
      bought from Cadence. For more information, see:
 
-     - `Build SOF with a Third-Party Toolchain <https://thesofproject.github.io/latest/getting_started/build-guide/build-3rd-party-toolchain.html>`_
+     - :ref:`build-3rd-party-toolchain`
 
      - `Cadence IP portfolio <https://ip.cadence.com/ipportfolio/tensilica-ip>`_
 


### PR DESCRIPTION
Switch internal links to `:ref:` per https://thesofproject.github.io/latest/contribute/doc_guidelines.html#internal-cross-reference-linking
    
`:ref:` internal links support offline work and don't die silently when someone changes a section name.

Fixes 37a14b1e352a, b270e65e19e15 and 2d4a0600fb9db