### PR TITLE
Unhardcode -master aliases and two https: links

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -163,10 +163,13 @@ numfig_format = {'figure': 'Figure %s', 'table': 'Table %s', 'code-block': 'Code
 
 SOF_GIT = 'https://github.com/thesofproject'
 
+# "/sof/tree/branch/dir" is for directories and "/sof/blob/branch/file" is
+# for files. Fortunately github automatically redirects one to the other
+# as required.
 extlinks = {
-    'git-sof-master':
+    'git-sof-mainline':
        (SOF_GIT + '/sof/tree/master/%s', ""),
-    'git-sof-docs-master':
+    'git-sof-docs-mainline':
        (SOF_GIT + '/sof-docs/tree/master/%s', ""),
     'git-alsa':
     ('https://git.alsa-project.org/?p=%s.git', ""),

--- a/contribute/contribute_guidelines.rst
+++ b/contribute/contribute_guidelines.rst
@@ -20,8 +20,7 @@ software continues to be available under the terms that the author
 desired.
 
 The SOF project uses a BSD-3-Clause license, as found in the
-`LICENSE <https://github.com/thesofproject/sof/blob/master/LICENSE>`__
-in the project's GitHub repo.
+:git-sof-mainline:`LICENCE` file in the project's GitHub repo.
 
 A license tells you what rights you have as a developer, as provided by
 the copyright holder. It is important that the contributor fully

--- a/contribute/process/abiprocess.rst
+++ b/contribute/process/abiprocess.rst
@@ -13,9 +13,8 @@ defined in:
 - src/include/ipc/
 - src/include/user/
 
-SOF ABI versioning is defined in firmware source code documentation `FW Source kernel/abi.h`_
-
-.. _FW Source kernel/abi.h: https://github.com/thesofproject/sof/blob/master/src/include/kernel/abi.h#L8
+SOF ABI versioning is defined in firmware source code documentation:
+:git-sof-mainline:`src/include/kernel/abi.h`
 
 Change Process
 **************

--- a/contribute/process/docbuild.rst
+++ b/contribute/process/docbuild.rst
@@ -148,10 +148,10 @@ tools:
    cd ~/thesofproject/sof-docs
    pip3 install --user -r scripts/requirements.txt
 
-.. note:: The :git-sof-docs-master:`scripts/requirements.txt` file hardcodes
+.. note:: The :git-sof-docs-mainline:`scripts/requirements.txt` file hardcodes
    versions using ``==``, which may not be compatible with your other
    projects. In that case you can either setup a Python ``virtualenv`` or
-   try the unsupported :git-sof-docs-master:`scripts/requirements-lax.txt`
+   try the unsupported :git-sof-docs-mainline:`scripts/requirements-lax.txt`
    (more details inside this file):
 
    .. code-block:: bash
@@ -226,7 +226,7 @@ diagrams. When done, view the HTML output with your browser, starting at
 
 If your changes are not related to any UML diagram, you can build more
 than 10 times faster from scratch by temporarily changing the
-``plantuml_output_format`` line in :git-sof-docs-master:`conf.py`.
+``plantuml_output_format`` line in :git-sof-docs-mainline:`conf.py`.
 
 Publish content
 ***************

--- a/getting_started/build-guide/build-from-scratch.rst
+++ b/getting_started/build-guide/build-from-scratch.rst
@@ -318,7 +318,7 @@ One-step rebuild from scratch
 -----------------------------
 
 To rebuild |SOF| in just one step, use
-:git-sof-master:`scripts/xtensa-build-all.sh` after setting up the
+:git-sof-mainline:`scripts/xtensa-build-all.sh` after setting up the
 environment.
 
 Build the firmware for all platforms.
@@ -510,8 +510,8 @@ Step 4 Build topology and tools
 One-step rebuild from scratch
 -----------------------------
 
-Without any argument :git-sof-master:`scripts/build-tools.sh` rebuilds
-only the minimum subset of :git-sof-master:`tools/`.
+Without any argument :git-sof-mainline:`scripts/build-tools.sh` rebuilds
+only the minimum subset of :git-sof-mainline:`tools/`.
 
 .. code-block:: bash
 


### PR DESCRIPTION
Rename `git-sof-[docs-]master` aliases to `-mainline`

Unhardcode two links.

See commit messages.