### PR TITLE
Add "--recurse-submodules" to git clone in build-with-docker

### DIFF
--- a/getting_started/build-guide/build-with-docker.rst
+++ b/getting_started/build-guide/build-with-docker.rst
@@ -27,7 +27,7 @@ Clone the *sof* repo.
 .. code-block:: bash
 
    cd "$SOF_WORKSPACE"
-   git clone https://github.com/thesofproject/sof.git
+   git clone --recurse-submodules https://github.com/thesofproject/sof.git
 
 Set up Docker
 *************


### PR DESCRIPTION
The docker-build scripts bake the builder's Intel-internal proxy settings into the docker image. If someone wants to build outside Intel, the easiest way to do so is to clone all the sources outside the container first.