### PR TITLE
developer guides: update components diagram

### DIFF
--- a/developer_guides/firmware/components/component-overview.rst
+++ b/developer_guides/firmware/components/component-overview.rst
@@ -83,6 +83,10 @@ Handle the component device state
 .. uml:: images/comp-dev-states.pu
    :caption: Component Device States
 
+.. note::
+
+   COMP_STATE_SUSPEND is not used currently.
+
 Refer to :c:func:`comp_set_state` in :ref:`component-api` for details.
 
 Implement the component API (comp_ops)

--- a/developer_guides/firmware/components/images/comp-dev-states.pu
+++ b/developer_guides/firmware/components/images/comp-dev-states.pu
@@ -1,7 +1,9 @@
 hide empty description
-[*] -right-> COMP_STATE_READY : <b>comp_ops.new()</b>
+[*] -right-> COMP_STATE_INIT : start of <b>comp_ops.new()</b>
 
-COMP_STATE_READY -right-> COMP_STATE_PREPARE : <b>COMP_TRIGGER_PREPARE</b>
+COMP_STATE_INIT --> COMP_STATE_READY : end of <b>comp_ops.new()</b>
+
+COMP_STATE_READY ---> COMP_STATE_PREPARE : <b>COMP_TRIGGER_PREPARE</b>
 
 COMP_STATE_PREPARE --> COMP_STATE_ACTIVE : <b>COMP_TRIGGER_START</b>
 


### PR DESCRIPTION
Fixes #290 

Add COMP_STATE_INIT to the diagram.

Signed-off-by: Janusz Jankowski <janusz.jankowski@linux.intel.com>