### PR TITLE
travis: upgrade Ubuntu from LTS 18.04 to LTS 20.04 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: focal
 
 before_install:
     - sudo apt-get update -qq

--- a/conf.py
+++ b/conf.py
@@ -181,6 +181,8 @@ extlinks = {
 html_static_path = ['static']
 
 def setup(app):
+# add_stylesheet() was renamed to add_css_file() in sphinx 1.8 released
+# in September 2018. add_stylesheet() will be removed in sphinx 4.0
    app.add_stylesheet("sof-custom.css")
 
 # Custom sidebar templates, must be a dictionary that maps document names


### PR DESCRIPTION
More aligned with users.

Should make no difference to the officially supported and entirely
hardcoded pip3 configuration. Will help prepare any future sphinx
upgrade.
