### PR TITLE
getting_started: add vital kernel links

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -171,6 +171,8 @@ extlinks = {
        (SOF_GIT + '/sof/tree/master/%s', ""),
     'git-sof-docs-mainline':
        (SOF_GIT + '/sof-docs/tree/master/%s', ""),
+    'git-sof-kconfig':
+       (SOF_GIT + '/kconfig/tree/master/%s', ""),
     'git-alsa':
     ('https://git.alsa-project.org/?p=%s.git', ""),
 }

--- a/developer_guides/linux_driver/architecture/sof_driver_arch.rst
+++ b/developer_guides/linux_driver/architecture/sof_driver_arch.rst
@@ -315,7 +315,7 @@ The SOF HDMI/DP audio codec driver handles DP-MST audio streams transparently, a
 Kernel Configuration/Kconfig
 ****************************
 
-Refer to the `README <https://github.com/thesofproject/kconfig/blob/master/README.md/>`_ file of the SOF kconfig `repository <https://github.com/thesofproject/kconfig/>`_.
+Refer to the :git-sof-kconfig:`README.md` file of the SOF kconfig repository.
 
 Debug Options
 *************

--- a/getting_started/build-guide/build-from-scratch.rst
+++ b/getting_started/build-guide/build-from-scratch.rst
@@ -556,8 +556,14 @@ the target machine's /usr/bin directory.
 Build Linux kernel
 ******************
 
-|SOF| uses the Linux kernel dev branch, and it must work with other dev branch
-firmware and topology.
+|SOF| uses the Linux kernel dev branch, and it must work with other dev
+branch firmware and topology. This short section shows how to build
+Debian kernel packages tested on Ubuntu in a small number of commands.
+However these commands rebuild everything from scratch every time which
+makes then unsuitably slow for development. If you need to make kernel
+code changes then ignore this and look at
+:ref:`setup-ktest-environment`, the :git-sof-kconfig:`README.md` file of
+the kconfig repo and the :ref:`sof_driver_arch`.
 
 #. Build the kernel with this branch.
 


### PR DESCRIPTION
Due to the lack of these links, the very first time I read this section
I assumed there was no other "kernel HOWTO" than this section elsewhere
in sof-docs and I did not search for anything else. So I did obviously
not find the pages linked to by this commit and I tried to figure
everything on my own instead which probably caused my biggest waste of
time when starting to work on SOF. No exaggeration.

I'm not sure why the ktest section is placed under "Setting up SOF on
hardware", maybe a different location for it would have helped me
too. Anyway adding a couple links is much easier than moving sections
around and a getting started guide is a good place for links to more
advanced documentation in any case. This getting started guide has
surprisingly few such links to more advanced topics.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>