### PR TITLE
Corrected broken link for kconfig README doc.

### DIFF
--- a/developer_guides/linux_driver/architecture/sof_driver_arch.rst
+++ b/developer_guides/linux_driver/architecture/sof_driver_arch.rst
@@ -315,7 +315,7 @@ The SOF HDMI/DP audio codec driver handles DP-MST audio streams transparently, a
 Kernel Configuration/Kconfig
 ****************************
 
-Refer to the :git-sof-kconfig:`README.md` file of the SOF kconfig repository.
+Refer to the `README <https://github.com/thesofproject/kconfig/blob/master/README.md/>`_ file of the SOF kconfig repository.
 
 Debug Options
 *************

--- a/getting_started/build-guide/build-from-scratch.rst
+++ b/getting_started/build-guide/build-from-scratch.rst
@@ -559,11 +559,11 @@ Build Linux kernel
 |SOF| uses the Linux kernel dev branch, and it must work with other dev
 branch firmware and topology. This short section shows how to build
 Debian kernel packages tested on Ubuntu in a small number of commands.
-However these commands rebuild everything from scratch every time which
+Note that these commands rebuild everything from scratch every time which
 makes then unsuitably slow for development. If you need to make kernel
-code changes then ignore this and look at
-:ref:`setup-ktest-environment`, the :git-sof-kconfig:`README.md` file of
-the kconfig repo and the :ref:`sof_driver_arch`.
+code changes, ignore this and look at
+:ref:`setup-ktest-environment`, the `README <https://github.com/thesofproject/kconfig/blob/master/README.md/>`_ file of
+the kconfig repo, and the :ref:`sof_driver_arch`.
 
 #. Build the kernel with this branch.
 


### PR DESCRIPTION
Signed-off-by: Deb Taylor <deb.taylor@intel.com>