### PR TITLE
Convert .travis.yml to github actions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,107 @@
+---
+# Tools that can save round-trips to github and a lot of time:
+#
+# yamllint -f parsable pull_request.yml
+# pip3 install ruamel.yaml.cmd
+# yaml merge-expand pull_request.yml exp.yml &&
+#    diff -w -u pull_request.yml exp.yml
+#
+# github.com also has a powerful web editor that can be used without
+# committing.
+
+name: Pull Requests
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# As of January 2021, no YAML anchors :-(
+env:
+  ubuntu_base_deps: doxygen make default-jre graphviz cmake ninja-build
+
+jobs:
+
+  supported-reqs:
+
+    name: 'Supported scripts/requirements.txt'
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: apt-get install
+        run: sudo apt-get -y install $ubuntu_base_deps
+
+      - name: PATH += .local/bin
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: 'pip install -r scripts/requirements.txt'
+        run: pip install -r scripts/requirements.txt
+
+      # No YAML anchors; this is copy/paste
+      - name: configure SOF doc
+        run: |
+          git clone https://github.com/thesofproject/sof
+          cmake -GNinja -S sof/doc -B _build_doxy
+
+      # TODO: change the (bad) default value for SOF_DOC_BUILD in
+      # sof-docs/Makefile and remove this command line override
+      - name: build
+        run: |
+          make html VERBOSE=1 SOF_DOC_BUILD=_build_doxy
+          du -shc _build*/*
+
+  lax:
+
+    name: "PIP_IGNORE_INSTALLED=0 requirements-lax.txt"
+    runs-on: ubuntu-20.04
+    # Makefile downgrades the Sphinx warnings, they are not errors any more
+    env: {LAX: 1}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: apt-get install base dependencies
+        run: sudo apt-get -y install $ubuntu_base_deps
+
+      - name: temporary python3-pil HACK because github is out of date
+        run: sudo apt-get -y install libimagequant0 libwebpdemux2 &&
+           wget http://security.ubuntu.com/ubuntu/ubuntu/pool/main/p/pillow/python3-pil_7.0.0-4ubuntu0.2_amd64.deb &&
+           sudo dpkg -i python3-pil_*.deb
+
+      - name: apt-get instead of pip
+        run: sudo apt-get -y install
+               python3-pip python3-setuptools python3-wheel
+               python3-sphinx python3-breathe python3-docutils
+               python3-sphinx-rtd-theme python3-sphinxcontrib.plantuml
+
+      - name: PATH += .local/bin
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      # should be a no-op
+      - name: 'pip install -r scripts/requirements-lax.txt'
+        run: pip install -r scripts/requirements-lax.txt
+
+      - name: config tweaks
+        run: |
+           # sphinx-build < 1.7 doesn't support "auto" and we're not sure
+           # all default modules are "thread-safe"
+           sed -i -e '/SPHINXBUILD/ s/-j *auto/-j 1/' Makefile
+           # We don't want plantUML to raise the contribution bar
+           sed -i -e 's/^\(plantuml_output_format *=\).*/\1 "none"/' conf.py
+
+      # No YAML anchors; this is copy/paste
+      - name: configure SOF doc
+        run: |
+          git clone https://github.com/thesofproject/sof
+          cmake -GNinja -S sof/doc -B _build_doxy
+
+      - name: build
+        run: |
+          make html VERBOSE=1 SOF_DOC_BUILD=_build_doxy
+          du -shc _build*/*


### PR DESCRIPTION
"deploy" steps not converted yet. I have never seen them run, are they
still in use?

Either way this first and most important part can be merged already.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>