### PR TITLE
Addition of files used to run Woke word checker.

### DIFF
--- a/.wokeignore
+++ b/.wokeignore
@@ -1,0 +1,20 @@
+# The following files can be ignored when running Woke.
+
+rules-woke.yaml
+conf.py
+*.pu
+tox.ini
+Makefile
+.travis.yml
+.github/workflows/*.yml
+index.rst
+release.rst
+introduction/index.rst
+maintainers/merge_rights.rst
+contribute/process/bug-tracking.rst
+getting_started/setup/setup_up_2_board.rst
+developer_guides/virtualization/files/q-v6.sh
+developer_guides/topology/topology.rst
+developer_guides/fuzzing/testbench_afl_fuzzing.rst
+
+

--- a/rules-woke.yaml
+++ b/rules-woke.yaml
@@ -1,0 +1,39 @@
+# Use this customized file to ensure that non-inclusive language is identified
+# and corrected. Keep it in the top level of the sof-docs directory.
+# Customization and improvement of this file is ongoing.
+# The following command calls this file:
+#  woke -c ./rules-woke.yaml
+
+rules:
+  - name: whitelist
+    terms:
+      - whitelist
+      - white-list
+    alternatives:
+      - allowlist
+
+  - name: blacklist
+    terms:
+      - blacklist
+      - black-list
+    alternatives:
+      - blocklist
+
+  - name: slave
+    terms:
+      - slave
+    alternatives:
+      - secondary for firmware-related topics and consumer for hardware-related topics
+
+  - name: master
+    terms:
+      - master
+    alternatives:
+      - main for firmware-related topics and provider for hardware-related topics
+
+  - name: rule of thumb
+    terms:
+      - rule of thumb
+      - rules of thumb
+    alternative:
+      - rule, rules


### PR DESCRIPTION
Signed-off-by: Deb Taylor <deb.taylor@intel.com>

Includes two files:
.wokeignore lists files to ignore when running Woke.
rules-woke.yaml is the customized file that must be run to accurately identify and correct non-inclusive terms.
    This file is called by woke -c ./rules-woke.yaml