### PR TITLE
zephyr: update installation instructions

### DIFF
--- a/getting_started/build-guide/build-with-zephyr.rst
+++ b/getting_started/build-guide/build-with-zephyr.rst
@@ -7,7 +7,7 @@ Build SOF with `Zephyr <https://zephyrproject.org/>`_
    :local:
    :depth: 3
 
-This guide describes the process of building and running |SOF| as a Zephyr
+This guide describes the process of building and running |SOF| as a `Zephyr`
 application.
 
 .. note::
@@ -18,17 +18,19 @@ application.
 Prepare
 *******
 
-The easiest way to build Zephyr is to use its recommended toolchain. Follow
+The easiest way to build `Zephyr` is to use its recommended toolchain. Follow
 instructions in
-`Install a Toolchain <https://docs.zephyrproject.org/latest/getting_started/index.html#install-a-toolchain>`_ for details.
+`Install a Toolchain <https://docs.zephyrproject.org/latest/getting_started/index.html#install-a-toolchain>`_
+for details.
 
 Check out and build
 *******************
 
-Zephyr uses ``west`` as a source management and building system. Follow the
-Zephyr `Getting Started <https://docs.zephyrproject.org/latest/getting_started/index.html#>`_ guide for dependencies and for ``west`` installation.
+`Zephyr` uses `west` as a source management and building system. Follow the
+`Zephyr` `Getting Started <https://docs.zephyrproject.org/latest/getting_started/index.html#>`_
+guide for dependencies and for `west` installation.
 
-Initialize a new ``west`` repository:
+Initialize a new `west` repository:
 
 .. code-block:: bash
 
@@ -37,43 +39,70 @@ Initialize a new ``west`` repository:
     west init
     west update
 
-This checks out all Zephyr sources, including SOF and rimage. Next, a
-firmware image can be built and signed:
+This checks out all `Zephyr` sources, including SOF. Additionally `rimage` has
+to be downloaded if it isn't yet available:
 
 .. code-block:: bash
 
-    west build -p -d build-apl -b intel_adsp_cavs15 zephyr/samples/audio/sof/
-    west sign -d build-apl -t rimage -- -k modules/audio/sof/keys/otc_private_key.pem
+    git clone --recurse-submodules https://github.com/thesofproject/rimage.git
 
-Note that the above uses the ``rimage`` signing tool, but it isn't built as
-a part of the process. If needed it can be built with:
+If you don't have an `rimage` executable yet installed on your system you can
+use this repository to build and optionally install one. This can be done by
 
 .. code-block:: bash
 
-    mkdir build-rimage
-    cd build-rimage
-    cmake ../modules/audio/sof/zephyr/ext/rimage/
+    mkdir rimage/build
+    cd rimage/build
+    cmake ..
     make
+    cd -
 
-Then you can add ``-p build-rimage/`` to the list of ``west sign`` parameters
-above (before the ``--`` separator).
+You also need it for platform-specific configuration.
+
+Next, a firmware image can be built and signed:
+
+.. code-block:: bash
+
+    west build -d build-apl -b intel_adsp_cavs15 -p zephyr/samples/audio/sof/
+    west sign -d build-apl -p rimage/build/rimage -t rimage -D rimage/config -- -k modules/audio/sof/keys/otc_private_key.pem
 
 .. note::
 
     If you need a different SOF version than the one automatically checked
-    out by ``west``, you can change to ``modules/audio/sof`` and use ``git``
+    out by `west`, you can change to ``modules/audio/sof`` and use `git`
     to select your preferred version. You need at least version 1.6 to use
-    it with Zephyr. Make sure you branch or tag your code in git; otherwise,
-    a future ``west update`` may lose it. See the ``west`` user guide.
+    it with `Zephyr`. Make sure you branch or tag your code in git; otherwise,
+    a future ``west update`` may lose it. See the `west` user guide.
 
 Run
 ***
 
-After the above instructions are completed, a firmware image is located at ``build-apl/zephyr/zephyr.ri``. It can be copied to the usual location on the
+After the above instructions are completed, a firmware image is located at
+``build-apl/zephyr/zephyr.ri``. It can be copied to the usual location on the
 target system. For example, if it is built natively, enter the following:
 
 .. code-block:: bash
 
     sudo cp build-apl/zephyr/zephyr.ri /lib/firmware/intel/sof/community/sof-cnl.ri
 
-For firmware log extraction, use ``zephyr/boards/xtensa/intel_adsp_cavs15/tools/logtool.py``.
+and reboot the system afterwards. Note, that the location and name of your SOF
+firmware image vary by system. Search your kernel logs for a line like
+
+    sof-audio-pci 0000:00:0e.0: request_firmware intel/sof/community/sof-apl.ri successful
+
+to identify which file under ``/lib/firmware/`` your hardware is using. After reboot
+verify, that the new firmware is being used by running
+
+.. code-block:: bash
+
+    dmesg | grep zephyr
+
+You should see something like
+
+    sof-audio-pci 0000:00:0e.0: Firmware info: used compiler GCC 9:2:0 zephyr used optimization flags -Os
+
+You might also need to build and update your system audio topology file. For
+details see :ref:`build-from-scratch`.
+
+For firmware log extraction, use
+``zephyr/boards/xtensa/intel_adsp_cavs15/tools/logtool.py``.


### PR DESCRIPTION
Update installation instructions under Zephyr to clarify post-installation verification and new rimage procedures.
