### PR TITLE
Grammatical edits to Build SOF with Zephyr

### DIFF
--- a/getting_started/build-guide/build-with-zephyr.rst
+++ b/getting_started/build-guide/build-with-zephyr.rst
@@ -7,8 +7,7 @@ Build SOF with `Zephyr <https://zephyrproject.org/>`_
    :local:
    :depth: 3
 
-This guide describes the process of building and running |SOF| as a `Zephyr`
-application.
+This guide describes how to build and run |SOF| as a Zephyr application.
 
 .. note::
 
@@ -18,91 +17,95 @@ application.
 Prepare
 *******
 
-The easiest way to build `Zephyr` is to use its recommended toolchain. Follow
-instructions in
-`Install a Toolchain <https://docs.zephyrproject.org/latest/getting_started/index.html#install-a-toolchain>`_
-for details.
+The easiest way to build Zephyr is to use its recommended toolchain. Follow
+instructions in `Install a Toolchain <https://docs.zephyrproject.org/latest/getting_started/index.html#install-a-toolchain>`_ for details.
 
 Check out and build
 *******************
 
-`Zephyr` uses `west` as a source management and building system. Follow the
-`Zephyr` `Getting Started <https://docs.zephyrproject.org/latest/getting_started/index.html#>`_
-guide for dependencies and for `west` installation.
+#. Install **west**.
+   Zephyr uses west as a source management and building system. Follow
+   the Zephyr `Getting Started <https://docs.zephyrproject.org/latest/getting_started/index.html#>`_ guide for dependencies and for the west installation.
 
-Initialize a new `west` repository:
+   .. note::
 
-.. code-block:: bash
+      If you need a different SOF version than the one that west
+      automatically checks out, change to ``modules/audio/sof`` and use git
+      to select your preferred version. You need at least version 1.6 to use
+      it with Zephyr. Make sure you branch or tag your code in git;
+      otherwise, a future ``west update`` may lose it. See the west user
+      guide.
 
-    mkdir $ZEPHYR_WORKSPACE
-    cd $ZEPHYR_WORKSPACE
-    west init
-    west update
+#. Initialize a new ``west`` repository. This checks out all Zephyr sources,
+   including SOF:
 
-This checks out all `Zephyr` sources, including SOF. Additionally `rimage` has
-to be downloaded if it isn't yet available:
+   .. code-block:: bash
 
-.. code-block:: bash
+      mkdir $ZEPHYR_WORKSPACE
+      cd $ZEPHYR_WORKSPACE
+      west init
+      west update
 
-    git clone --recurse-submodules https://github.com/thesofproject/rimage.git
+#. Download **rimage** if you haven't already done so:
 
-If you don't have an `rimage` executable yet installed on your system you can
-use this repository to build and optionally install one. This can be done by
+   .. code-block:: bash
 
-.. code-block:: bash
+      git clone --recurse-submodules https://github.com/thesofproject/rimage.git
 
-    mkdir rimage/build
-    cd rimage/build
-    cmake ..
-    make
-    cd -
+   If you need to install a rimage executable on your system, use this
+   repository to build and optionally install one:
 
-You also need it for platform-specific configuration.
+   .. code-block:: bash
 
-Next, a firmware image can be built and signed:
+      mkdir rimage/build
+      cd rimage/build
+      cmake ..
+      make
+        cd -
 
-.. code-block:: bash
+   You also need it for platform-specific configuration.
 
-    west build -d build-apl -b intel_adsp_cavs15 -p zephyr/samples/audio/sof/
-    west sign -d build-apl -p rimage/build/rimage -t rimage -D rimage/config -- -k modules/audio/sof/keys/otc_private_key.pem
+#. Build and sign a firmware image:
 
-.. note::
+   .. code-block:: bash
 
-    If you need a different SOF version than the one automatically checked
-    out by `west`, you can change to ``modules/audio/sof`` and use `git`
-    to select your preferred version. You need at least version 1.6 to use
-    it with `Zephyr`. Make sure you branch or tag your code in git; otherwise,
-    a future ``west update`` may lose it. See the `west` user guide.
+      west build -d build-apl -b intel_adsp_cavs15 -p zephyr/samples/audio/sof/
+      west sign -d build-apl -p rimage/build/rimage -t rimage -D rimage/config -- -k  nmodules/audio/sof/keys/otc_private_key.pem
 
 Run
 ***
 
 After the above instructions are completed, a firmware image is located at
-``build-apl/zephyr/zephyr.ri``. It can be copied to the usual location on the
-target system. For example, if it is built natively, enter the following:
+``build-apl/zephyr/zephyr.ri``. 
 
-.. code-block:: bash
+#. Copy the firmware image (``build-apl/zephyr/zephyr.ri``) to the usual
+   location on your target system. For example, if it is built natively,
+   enter the following:
 
-    sudo cp build-apl/zephyr/zephyr.ri /lib/firmware/intel/sof/community/sof-cnl.ri
+   .. code-block:: bash
 
-and reboot the system afterwards. Note, that the location and name of your SOF
-firmware image vary by system. Search your kernel logs for a line like
+      sudo cp build-apl/zephyr/zephyr.ri /lib/firmware/intel/sof/community/sof-cnl.ri
 
-    sof-audio-pci 0000:00:0e.0: request_firmware intel/sof/community/sof-apl.ri successful
+#. Reboot the system. Note that the location and name of your SOF
+   firmware image may vary by system. Search your kernel logs for a line
+   such as the following to identify which file under ``/lib/firmware/`` your hardware is using:
 
-to identify which file under ``/lib/firmware/`` your hardware is using. After reboot
-verify, that the new firmware is being used by running
+   ``sof-audio-pci 0000:00:0e.0: request_firmware intel/sof/community/sof-apl.ri successful``
 
-.. code-block:: bash
+#. Verify that the new firmware is being used by running the following:
 
-    dmesg | grep zephyr
+   .. code-block:: bash
 
-You should see something like
+      dmesg | grep zephyr
 
-    sof-audio-pci 0000:00:0e.0: Firmware info: used compiler GCC 9:2:0 zephyr used optimization flags -Os
+   You should see a line such as the following:
+
+   ``sof-audio-pci 0000:00:0e.0: Firmware info: used compiler GCC 9:2:0 zephyr used optimization flags -Os``
+
+For firmware log extraction, use
+``zephyr/boards/xtensa/intel_adsp_cavs15/tools/logtool.py``.
 
 You might also need to build and update your system audio topology file. For
 details see :ref:`build-from-scratch`.
 
-For firmware log extraction, use
-``zephyr/boards/xtensa/intel_adsp_cavs15/tools/logtool.py``.
+


### PR DESCRIPTION
Signed-off-by: Deb <deb.taylor@intel.com>

Zephyr, west, and rimage do not need to be italicized. 

Created numbered steps for both sections.

Tried to make this doc look more like Zephyr's documentation in terms of style.