### PR TITLE
Removed reference to "master" in cavs-dsp-boot-overview doc

### DIFF
--- a/architectures/dsp/intel/cavs-boot/cavs-dsp-boot-overview.rst
+++ b/architectures/dsp/intel/cavs-boot/cavs-dsp-boot-overview.rst
@@ -125,5 +125,3 @@ Booting with Boot Loader
 
 .. uml:: images/boot-ldr-flow.pu
    :caption: SOF Boot Loader Flow
-
-.. comment "master" has been replaced with "primary"


### PR DESCRIPTION
Signed-off-by: Deb <deb.taylor@intel.com>