### PR TITLE
switch the build guide to gcc10.2-gdb9 (which works) and add Tiger Lake information

### DIFF
--- a/getting_started/build-guide/build-from-scratch.rst
+++ b/getting_started/build-guide/build-from-scratch.rst
@@ -335,9 +335,9 @@ Build the firmware for all platforms.
    This script will only work if the PATH includes both the cross-compiler and
    ``xtensa-root`` and if they are siblings in the same ``sof`` directory.
 
-As of April 2020, you may specify one or more of the following platform
-arguments: ``byt``, ``cht``, ``hsw``, ``bdw``, ``apl``, ``cnl``,
-``sue``, ``icl``, ``jsl``, ``imx8``, ``imx8x``, ``imx8m``. Example:
+As of May 2021, you may specify one or more of the following platform
+arguments: ``byt``, ``cht``, ``bdw``, ``hsw``, ``apl``, ``skl``, ``kbl``, ``cnl``,
+``sue``, ``icl``, ``jsl``, ``tgl``, ``tgl-h``, ``imx8``, ``imx8x``, ``imx8m``. Example:
 
 .. code-block:: bash
 

--- a/getting_started/build-guide/build-from-scratch.rst
+++ b/getting_started/build-guide/build-from-scratch.rst
@@ -8,7 +8,7 @@ Build SOF from scratch
    :depth: 3
 
 You may boot and test |SOF| on a target machine or VM. Current target
-Intel platforms include: |BYT|, |CHT|, |HSW|, |BDW|, |APL|, |CNL|, |ICL| and |JSL|.
+Intel platforms include: |BYT|, |CHT|, |HSW|, |BDW|, |APL|, |CNL|, |ICL|, |JSL| and |TGL|.
 
 Support also exists for NXP i.MX8/i.MX8X/i.MX8M platforms.
 
@@ -153,7 +153,7 @@ Step 2 Build toolchains from source
 ===================================
 
 Build the xtensa cross-compilation toolchains with crosstool-ng for Intel |BYT|,
-|CHT|, |HSW|, |BDW|, |APL|, |CNL|, |ICL|, |JSL| platforms and NXP i.MX8/i.MX8X/i.MX8M
+|CHT|, |HSW|, |BDW|, |APL|, |CNL|, |ICL|, |JSL|, |TGL| platforms and NXP i.MX8/i.MX8X/i.MX8M
 platforms.
 
 crosstool-ng
@@ -200,7 +200,7 @@ download gcc components.
    # Apollo Lake
    cp config-apl-gcc10.2-gdb9 .config
    ./ct-ng build
-   # Cannon Lake, Ice Lake and Jasper Lake
+   # Cannon Lake, Ice Lake, Jasper Lake and Tiger Lake
    cp config-cnl-gcc10.2-gdb9 .config
    ./ct-ng build
    # i.MX8/i.MX8X
@@ -235,7 +235,7 @@ default values missing from it:
 
    |BYT| and |CHT| share the same toolchain: xtensa-byt-elf
 
-   |CNL|, |ICL| and |JSL| share the same toolchain: xtensa-cnl-elf
+   |CNL|, |ICL|, |JSL| and |TGL| share the same toolchain: xtensa-cnl-elf
 
    i.MX8 and i.MX8X share the same toolchain: xtensa-imx-elf
 
@@ -283,7 +283,7 @@ Build and install for each platform.
    make
    make install
    rm -fr rm etc/config.cache
-   # Cannon Lake, Ice Lake and Jasper Lake
+   # Cannon Lake, Ice Lake, Jasper Lake and Tiger Lake
    ./configure --target=xtensa-cnl-elf --prefix="${XTENSA_ROOT}"
    make
    make install
@@ -455,6 +455,24 @@ for |JSL|:
    mkdir build_jsl && cd build_jsl
    cmake -DTOOLCHAIN=xtensa-cnl-elf -DROOT_DIR="$XTENSA_ROOT"/xtensa-cnl-elf ..
    make jasperlake_defconfig
+   make bin -j4
+
+for |TGL|:
+
+.. code-block:: bash
+
+   mkdir build_tgl && cd build_tgl
+   cmake -DTOOLCHAIN=xtensa-cnl-elf -DROOT_DIR="$XTENSA_ROOT"/xtensa-cnl-elf ..
+   make tgplp_defconfig
+   make bin -j4
+
+for |TGL| H:
+
+.. code-block:: bash
+
+   mkdir build_tgl-h && cd build_tgl-h
+   cmake -DTOOLCHAIN=xtensa-cnl-elf -DROOT_DIR="$XTENSA_ROOT"/xtensa-cnl-elf ..
+   make tgph_defconfig
    make bin -j4
 
 for i.MX8:

--- a/getting_started/build-guide/build-from-scratch.rst
+++ b/getting_started/build-guide/build-from-scratch.rst
@@ -159,7 +159,7 @@ platforms.
 crosstool-ng
 ------------
 
-Clone both repos and check out the ``sof-gcc8.1`` branch.
+Clone both repos and check out the ``sof-gcc10.2`` and ``sof-gcc10x`` branch.
 
 .. code-block:: bash
 
@@ -167,9 +167,9 @@ Clone both repos and check out the ``sof-gcc8.1`` branch.
    git clone https://github.com/thesofproject/xtensa-overlay
    git clone https://github.com/thesofproject/crosstool-ng
    cd xtensa-overlay
-   git checkout sof-gcc8.1
+   git checkout sof-gcc10.2
    cd ../crosstool-ng
-   git checkout sof-gcc8.1
+   git checkout sof-gcc10x
 
 Build crosstool-ng and install it in its own source directory.
 
@@ -192,34 +192,34 @@ download gcc components.
 .. code-block:: bash
 
    # Baytrail/Cherrytrail
-   cp config-byt-gcc8.1-gdb8.1 .config
+   cp config-byt-gcc10.2-gdb9 .config
    ./ct-ng build
    # Haswell/Broadwell
-   cp config-hsw-gcc8.1-gdb8.1 .config
+   cp config-hsw-gcc10.2-gdb9 .config
    ./ct-ng build
    # Apollo Lake
-   cp config-apl-gcc8.1-gdb8.1 .config
+   cp config-apl-gcc10.2-gdb9 .config
    ./ct-ng build
    # Cannon Lake, Ice Lake and Jasper Lake
-   cp config-cnl-gcc8.1-gdb8.1 .config
+   cp config-cnl-gcc10.2-gdb9 .config
    ./ct-ng build
    # i.MX8/i.MX8X
-   cp config-imx-gcc8.1-gdb8.1 .config
+   cp config-imx-gcc10.2-gdb9 .config
    ./ct-ng build
    # i.MX8M
-   cp config-imx8m-gcc8.1-gdb8.1 .config
+   cp config-imx8m-gcc10.2-gdb9 .config
    ./ct-ng build
 
 ``./ct-ng`` is a Linux kernel style Makefile; so the sample commands below
-can be used to fix some out of date ``config-*-gcc8.1-gdb8.1`` file or find
+can be used to fix some out of date ``config-*-gcc10.2-gdb9`` file or find
 default values missing from it:
 
 .. code-block:: bash
 
    ./ct-ng help
-   cp config-apl-gcc8.1-gdb8.1 .config
+   cp config-apl-gcc10.2-gdb9 .config
    ./ct-ng oldconfig V=1
-   diff -u config-apl-gcc8.1-gdb8.1 .config
+   diff -u config-apl-gcc10.2-gdb9 .config
 
 "Install" toolchains by copying them to ``$SOF_WORKSPACE``.
 

--- a/substitutions.txt
+++ b/substitutions.txt
@@ -11,6 +11,7 @@
 .. |CNL| replace:: Cannon Lake
 .. |ICL| replace:: Ice Lake
 .. |JSL| replace:: Jasper Lake
+.. |TGL| replace:: Tiger Lake
 .. |TSC| replace:: Technical Steering Committee
 
 .. These are replacement strings for non-ASCII characters used within the project


### PR DESCRIPTION
crosstool-ng fails to build with the gcc8.1-gdb8.1 configs and while there update the page for Tiger Lake as well.