### PR TITLE
build-guide: Correct ct-ng path for building all toolchains

### DIFF
--- a/getting_started/build-guide/build-from-scratch.rst
+++ b/getting_started/build-guide/build-from-scratch.rst
@@ -232,7 +232,7 @@ to build all toolchains without interruption:
 .. code-block:: bash
 
    time for i in config*gcc10.2-gdb9; do
-      cp "$i" .config && ../ct-install/bin/ct-ng build || break ;
+      cp "$i" .config && ./ct-ng build || break ;
    done
 
 


### PR DESCRIPTION
There is no mention in the documentation about "ct-install", the ct-ng is
installed in previous steps to $(pwd).

Fixes: a31ee37bae5f2 ("Toolchains and getting started guide: remove duplication, other fixes")
Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>