### PR TITLE
build-guide: Add instructions about ubuntu's build-essential metapackage

### DIFF
--- a/getting_started/build-guide/build-from-scratch.rst
+++ b/getting_started/build-guide/build-from-scratch.rst
@@ -41,8 +41,14 @@ Step 0 Set up the workspace directory
 Step 1 Set up build environment
 ===============================
 
-Install packaged dependencies
------------------------------
+Install packaged dependencies (Ubuntu)
+--------------------------------------
+
+Make sure that ``build-essential`` is installed:
+
+.. code-block:: bash
+
+   sudo apt-get install build-essential
 
 * For Ubuntu 18.10:
 


### PR DESCRIPTION
Developers must have the build-essential installed. It is highly unlikely
that a developer does not have it already, but for the sake of completeness
add a note about it.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>