### PR TITLE
Fix unit tests documentation

### DIFF
--- a/developer_guides/firmware/cmake.rst
+++ b/developer_guides/firmware/cmake.rst
@@ -107,6 +107,8 @@ Unit Tests
 
 Optional arguments. Only for unit tests.
 
+Read :ref:`unit_tests` first.
+
 BUILD_UNIT_TESTS
    Default: OFF, if ON then builds unit tests.
 


### PR DESCRIPTION
Explain how to "steal" parameters from scripts/xtensa-build-all.sh

Explain how to compile natively.

Link the two sections with each other.

`make platform_defconfig` was obsolete, replace with -DINIT_CONFIG

Signed-off-by: Marc Herbert <marc.herbert@intel.com>