### PR TITLE
Add mt8195 mediatek platform information to the table.

### DIFF
--- a/platforms/index.rst
+++ b/platforms/index.rst
@@ -26,6 +26,7 @@ Platform and board specific support is continually added to the SOF project as d
    "NXP i.MX8/i.MX8X", "Xtensa HiFi4", "1 @ 666MHz", "64 KB TCM / 448 KB OCRAM / 8MB SDRAM", "1 x ESAI, 1 x SAI"
    "NXP i.MX8M", "Xtensa HiFi4", "1 @ 800MHz", "64 KB TCM / 256 KB OCRAM / 8MB SDRAM", "1 x SAI, MICFIL"
    "AMD Renoir", "Xtensa HiFi3", "1 @ 600MHz", "20 KB LP SRAM / 1152 KB IRAM/DRAM", "1 x SP (I2S, PCM), 1 x BT (I2S, PCM), DMIC"
+   "Mediatek mt8195", "Xtensa HiFi4", "1 @ 220 - 720MHz", "256 KB SRAM / 16 MB DRAM", "2 x TDM Out, 1 x TDM In, DMIC"
 
 When support for a new platform is being added, certain interfaces required by
 SOF infrastructure must be implemented. Refer to Platform API documentation


### PR DESCRIPTION
Add mt8195 mediatek platform information to the table.
Included clock, memory and audio controller instances to the table

Signed-off-by: YC Hung <yc.hung@mediatek.com>
Signed-off-by: Allen-KH Cheng <allen-kh.cheng@mediatek.com>