### PR TITLE
Add a global site tag from Linux Foundation for Google Analytics

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -119,7 +119,7 @@ else:
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
     html_theme_options = {
         'canonical_url': '',
-        'analytics_id': '',
+        'analytics_id': 'GTM-M4BL5NF',
         'logo_only': False,
         'display_version': True,
         'prev_next_buttons_location': 'None',


### PR DESCRIPTION
Added the global tag that was provided by Linux Foundation to the sphinx-rtd-theme parameters. This should allow collecting web analytics from the documentation site.