### PR TITLE
build-from-scratch: Minor fix to local alsa-utils install command

### DIFF
--- a/getting_started/build-guide/build-from-scratch.rst
+++ b/getting_started/build-guide/build-from-scratch.rst
@@ -157,7 +157,9 @@ Clone, build, and install alsa-utils.
    # To install alsa-utils locally
    ./gitcompile --prefix=$HOME/local \
                 --with-alsa-inc-prefix=$HOME/local/include \
-		--with-alsa-prefix=$HOME/local/lib
+		--with-alsa-prefix=$HOME/local/lib \
+		--with-systemdsystemunitdir=$HOME/local/lib/systemd \
+		--with-udev-rules-dir=$HOME/locallib/udev
    sudo make install
 
 If you run into alsa-lib linking errors, try to re-build it with the libdir


### PR DESCRIPTION
Do not mess with the host systemd or udev conf if making local
installation to home directory.

Signed-off-by: Jyri Sarha <jyri.mikko.oskari.sarha@intel.com>