### PR TITLE
build-with-zephyr: fix submodules, get ready for new python script

### DIFF
--- a/getting_started/build-guide/build-with-zephyr.rst
+++ b/getting_started/build-guide/build-with-zephyr.rst
@@ -30,8 +30,8 @@ Check out and build
    .. note::
 
       If you need a different SOF version than the one that west
-      automatically checks out, change to ``modules/audio/sof`` and use git
-      to select your preferred version. You need at least version 1.6 to use
+      automatically checks out, instructions below show how to change ``modules/audio/sof``
+      and select your preferred version. You need at least Zephyr version 1.6 to use
       it with Zephyr. Make sure you branch or tag your code in git;
       otherwise, a future ``west update`` may lose it. See the west user
       guide.
@@ -46,15 +46,19 @@ Check out and build
       cd $ZEPHYR_WORKSPACE
       west update hal_xtensa sof
 
-#. Build and sign a firmware image:
+#. Make sure the appropriate Zephyr SDK or other toolchain of your
+   choice can be found for your desired ``--board`` and that every
+   other Zephyr dependency is set up properly:
 
    .. code-block:: bash
 
-      cd $ZEPHYR_WORKSPACE
-      ./modules/audio/sof/scripts/xtensa-build-zephyr.sh -h  # shows usage
-      ./modules/audio/sof/scripts/xtensa-build-zephyr.sh $your_platforms
-      ls build-*/zephyr/zephyr.*
-        => build-*/zephyr/zephyr.ri ...
+      ls zephyr/boards/xtensa/
+      west build --board intel_adsp_cavs25 ./zephyr/samples/subsys/audio/sof/
+
+   For now the ``.elf`` file produced by ``west build`` is missing a
+   manifest and signature. The wrapper script below invokes *both*
+   ``west build`` and ``west sign`` and produces a complete ``.ri``
+   file; you won't need to call ``west build`` again.
 
 #. Fetch and switch to the latest SOF code
 
@@ -69,8 +73,29 @@ Check out and build
      git fetch sof
      git switch --track sof/main
 
-   You can also delete the ``sof`` clone downloaded by ``west`` and
-   replace it with an older clone; west will automatically adjust.
+     # If needed, correct submodule URLs in .git/config with latest .gitmodules file.
+     git submodule sync --recursive
+     # Download submodules
+     git submodule update --init --recursive
+
+   Alternatively, feel free to delete the ``sof`` clone downloaded by
+   ``west`` and replace it with any other ``sof`` clone you already
+   have; west will automatically adjust.
+
+#. Build and sign a firmware image:
+
+   .. code-block:: bash
+
+      cd $ZEPHYR_WORKSPACE
+      ./modules/audio/sof/scripts/xtensa-build-zephyr.sh -h  # shows usage
+      ./modules/audio/sof/scripts/xtensa-build-zephyr.sh $your_platforms
+      ls build-*/zephyr/zephyr.*
+        => build-*/zephyr/zephyr.ri ...
+
+
+There is work in progress to substitute ``xtensa-build-zephyr.sh`` with
+a Python replacement ``xtensa-build-zephyr.py`` for Windows
+compatibility. It can already be used in many cases.
 
 Run
 ***

--- a/getting_started/build-guide/build-with-zephyr.rst
+++ b/getting_started/build-guide/build-with-zephyr.rst
@@ -41,10 +41,9 @@ Check out and build
 
    .. code-block:: bash
 
-      mkdir $ZEPHYR_WORKSPACE
-      cd $ZEPHYR_WORKSPACE
-      west init
+      west init $ZEPHYR_WORKSPACE
       # Significantly smaller and faster than a full "west update"
+      cd $ZEPHYR_WORKSPACE
       west update hal_xtensa sof
 
 #. Build and sign a firmware image:


### PR DESCRIPTION
Add missing `git submodule update` as reported by @plbossart (thx!)

Also make the documentation ready for `xtensa-build-zephyr.py`
which... does not have any hack to automatically download git submodules
like the older .sh script has.

As a side-effect, this breaks down the process and adds an intermediate
`west build` step which removes one layer of indirection in case of some
Zephyr environment issue.

Cannot fully switch to the Python version yet because of bugs like
https://github.com/thesofproject/sof/pull/5906 but do recommend users to
start trying it.