### PR TITLE
.github: upgrade LAX environment to Ubuntu 22.04

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -102,7 +102,7 @@ jobs:
 
   lax:
     name: "PIP_IGNORE_INSTALLED=0 requirements-lax.txt"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # Makefile downgrades the Sphinx warnings, they are not errors any more
     env: {LAX: 1}
     steps:


### PR DESCRIPTION
Unlike scripts/requirements.txt, the purpose of
scripts/requirements-lax.txt is to run the latest and greatest.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>