### PR TITLE
conf.py: cpp_id_attributes = ["__sparse_cache"]

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -89,7 +89,7 @@ version = release = "2.0"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/conf.py
+++ b/conf.py
@@ -52,6 +52,12 @@ plantuml_output_format = 'svg'
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
+# Fixes "WARNING: Error when parsing function declaration."
+c_id_attributes = ["__sparse_cache"]
+# Not clear why Sphinx thinks some C files are C++
+cpp_id_attributes = c_id_attributes
+# cpp_paren_attributes = ["_ALIAS_OF", "__printf_like"]
+
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #

--- a/conf.py
+++ b/conf.py
@@ -174,13 +174,13 @@ SOF_GIT = 'https://github.com/thesofproject'
 # as required.
 extlinks = {
     'git-sof-mainline':
-       (SOF_GIT + '/sof/tree/master/%s', ""),
+       (SOF_GIT + '/sof/tree/master/%s', None),
     'git-sof-docs-mainline':
-       (SOF_GIT + '/sof-docs/tree/master/%s', ""),
+       (SOF_GIT + '/sof-docs/tree/master/%s', None),
     'git-sof-kconfig':
-       (SOF_GIT + '/kconfig/tree/master/%s', ""),
+       (SOF_GIT + '/kconfig/tree/master/%s', None),
     'git-alsa':
-    ('https://git.alsa-project.org/?p=%s.git', ""),
+    ('https://git.alsa-project.org/?p=%s.git', None),
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
With a recent enough sphinx-build --version, this fixes the gazillion of
warnings recently added:

```
/home/runner/work/sof-docs/sof-docs/api/component-api.rst:21: WARNING: Error when parsing function declaration.
If the function has no return type:
  Error in declarator or parameters-and-qualifiers
  Invalid C++ declaration: Expected identifier in nested name, got keyword: void [error at 18]
    static inline void comp_underrun (struct comp_dev *dev, struct comp_buffer __sparse_cache *source, uint32_t copy_bytes)
    ------------------^
If the function has a return type:
  Error in declarator or parameters-and-qualifiers
  If pointer to member declarator:
    Invalid C++ declaration: Expected '::' in pointer to member (function). [error at 33]
      static inline void comp_underrun (struct comp_dev *dev, struct comp_buffer __sparse_cache *source, uint32_t copy_bytes)
      ---------------------------------^
  If declarator-id:
    Invalid C++ declaration: Expecting "," or ")" in parameters-and-qualifiers, got "*". [error at 90]
      static inline void comp_underrun (struct comp_dev *dev, struct comp_buffer __sparse_cache *source, uint32_t copy_bytes)
      ------------------------------------------------------------------------------------------^
```