### PR TITLE
testbench: add note to install runtime deps

### DIFF
--- a/developer_guides/testbench/build_testbench.rst
+++ b/developer_guides/testbench/build_testbench.rst
@@ -3,6 +3,13 @@
 Build and Run Testbench
 #######################
 
+First, you'll need to install some dependencies to run the testbench:
+
+.. code-block:: bash
+
+   sudo apt install valgrind bc # For Ubuntu/Debian
+   sudo dnf install valgrind bc # For Fedora
+
 Retrieve the required firmware from the ``thesofproject`` repository in
 Github as described in :ref:`build-from-scratch`. Start a shell at the
 firmware repository top level in the ``$SOF_WORKSPACE/sof`` directory as also described.


### PR DESCRIPTION
I've found Valgrind and bc are necessary to run the testbench. Neither
are listed in the general dependency list for Ubuntu 20.04 and only
Valgrind is listed for other versions.

Signed-off-by: Noah Klayman <noah.klayman@intel.com>