### PR TITLE
Add missing code-block:: types

### DIFF
--- a/contribute/doc_guidelines.rst
+++ b/contribute/doc_guidelines.rst
@@ -386,7 +386,7 @@ the first non-white space in the preceding line.  For example:
    1. And for numbered list items, the continuation
       line should align with the text of the line above.
 
-   .. code-block::
+   .. code-block:: none
 
       The text within a directive block should align with the
       first character of the directive name.

--- a/developer_guides/topology/topology.rst
+++ b/developer_guides/topology/topology.rst
@@ -303,7 +303,7 @@ be scheduled.
 To specify the DSP core for a pipeline, use the SOF_TKN_SCHED_CORE token
 located in tools/topology/m4/pipeline.m4:
 
-.. code-block::
+.. code-block:: none
 
         W_PIPELINE(stream, period, priority, core, initiator, platform)
         ...
@@ -313,14 +313,14 @@ located in tools/topology/m4/pipeline.m4:
 Then specify this 'core' in your pipeline definition, such as in
 tools/topology/sof/pipe-dai-playback.m4:
 
-.. code-block::
+.. code-block:: none
 
         W_PIPELINE(N_DAI_OUT, SCHEDULE_PERIOD, SCHEDULE_PRIORITY, SCHEDULE_CORE, SCHEDULE_TIME_DOMAIN, pipe_dai_schedule_plat)
 
 To specify the DSP core for a component/widget, use the SOF_TKN_COMP_CORE_ID
 token located in tools/topology/m4/pga.m4:
 
-.. code-block::
+.. code-block:: none
 
         dnl W_PGA(name, format, periods_sink, periods_source, core, kcontrol0. kcontrol1...etc)
         ...

--- a/getting_started/intel_debug/introduction.rst
+++ b/getting_started/intel_debug/introduction.rst
@@ -71,7 +71,7 @@ The ``snd-intel-dspcfg`` module introduced in early 2020 exposes an API
 used by all drivers, and the user can now override default choices by
 setting the ``dsp_driver`` parameter. For example, setting
 
-.. code-block::
+.. code-block:: cfg
 
    options snd-intel-dspcfg dsp_driver=1
 
@@ -83,7 +83,7 @@ Conversely, when a platform does not require a DSP-based platform, but
 the DSP is still enabled by the OEM, the user or integration can
 force the SOF Linux driver to be used.
 
-.. code-block::
+.. code-block:: cfg
 
    options snd-intel-dspcfg dsp_driver=3
 

--- a/getting_started/intel_debug/suggestions.rst
+++ b/getting_started/intel_debug/suggestions.rst
@@ -58,7 +58,7 @@ issues are possible.
 
 Use the following commands to check if the SOF driver is functional at the hardware device level:
 
-.. code-block::
+.. code-block:: console
 
    speaker-test -Dhw:0,0 -c2 -r48000 -f S16_LE
    arecord -Dhw:0,0 -c2 -r48000 -f S16_LE -d 10 test.wav
@@ -95,7 +95,7 @@ may not be enough to debug a specific issue, and the recommendation is
 to add the following options to the ``/etc/modprobe.d/sof-dyndbg.conf``
 file:
 
-.. code-block::
+.. code-block:: cfg
 
    options snd_sof_intel_byt dyndbg=+p
    options snd_sof_intel_bdw dyndbg=+p
@@ -137,7 +137,7 @@ Trace support might need to be enabled on distribution kernels in case the
 ``/sys/kernel/debug/sof/trace`` file is not present by adding sof_debug=1 option
 to snd_sof module:
 
-.. code-block::
+.. code-block:: cfg
 
    options snd_sof sof_debug=1
 
@@ -152,7 +152,7 @@ On devices designed for Windows, the presence of the microphone is
 reported as an NHLT endpoint (ACPI table in the BIOS). The SOF Linux
 driver will report this information with a 'dmesg' log such as
 
-.. code-block::
+.. code-block:: none
 
    [    4.301490] sof-audio-pci-intel-tgl 0000:00:1f.3: DMICs detected in NHLT tables: 2
 
@@ -165,7 +165,7 @@ the value with a kernel parameter which can be added in
 /etc/modprobe.d/alsa-base.conf (or any other configuration file with
 this .conf extension). A reboot is necessary after changing the value
 
-.. code-block::
+.. code-block:: cfg
 
    options snd_sof_intel_hda_common dmic_num=4
 
@@ -191,7 +191,7 @@ necessary to override the file installed in
 5.20+ a kernel parameter will be enough with no need to change and
 override installed topology files, e.g.
 
-.. code-block::
+.. code-block:: cfg
 
    options snd-sof-pci tplg_filename=sof-hda-generic-2ch-pdm1.tplg
 
@@ -219,11 +219,11 @@ End-users can verify if the hardware uses this configuration by
 running the 'alsa-info' command and checking for the presence an ACPI
 _HID, e.g.
 
-.. code-block::
+.. code-block:: none
 
    /sys/bus/acpi/devices/ESSX8336:00/status 	 15
 
-.. code-block::
+.. code-block:: none
 
    /sys/bus/acpi/devices/ESSX8326:00/status 	 15
 
@@ -260,7 +260,7 @@ added with the following option in
 e.g. /etc/modprobe.d/alsa-base.conf. Only the bits listed above can be
 modified, others need to be kept as is.
 
-.. code-block::
+.. code-block:: cfg
 
    options snd_soc_sof_es8336 quirk=<value>
 

--- a/getting_started/setup_linux/setup_ktest_environment.rst
+++ b/getting_started/setup_linux/setup_ktest_environment.rst
@@ -65,7 +65,7 @@ Set up a target
 
    d) Update the grub configuration.
 
-      .. code-block::
+      .. code-block:: console
 	 
 	 sudo update-grub
 


### PR DESCRIPTION
Fixes many warnings found by sphinx 1.8.5 and likely other versions.

Don't forget to "make clean" so see all warnings.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>