### PR TITLE
requirements-lax: request sphinxcontrib.plantuml>=0.11,<0.25 

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -45,8 +45,9 @@ graphviz_dot_args=[
 plantuml = 'java -jar ' + os.path.join(os.path.abspath('.'), 'scripts/plantuml.jar') \
     + ' -config ' + os.path.join(os.path.abspath('.'), 'scripts/plantuml.cfg')
 
-# Temporarily set this to "none" for a build without diagrams but ~= 15
-# times faster from scratch.
+# Temporarily set this to "none" for a build with NO UML diagram but ~= 15
+# times faster from scratch. Requires sphinxcontrib.plantuml>=0.11
+# (of course don't do this when you're touching UML stuff)
 plantuml_output_format = 'svg'
 
 # Add any paths that contain templates here, relative to this directory.

--- a/scripts/requirements-lax.txt
+++ b/scripts/requirements-lax.txt
@@ -13,7 +13,21 @@ breathe>=4.7.3
 sphinx>=1.6.7
 docutils>=0.14
 sphinx_rtd_theme>=0.2.4
-sphinxcontrib-plantuml
+
+# - Version 0.11 is the first version that supports
+#   `plantuml_output_format=none` which makes the build at least 15
+#   times faster. https://pypi.org/project/sphinxcontrib-plantuml/0.11/
+#
+# - 0.24 is the last version successfully tested with
+#   PIP_IGNORE_INSTALLED=0 and Ubuntu 20.04 (see .github/worflows/)
+#
+# - Note 0.9 is the minimum to fix this fatal import failure:
+#
+#   sphinx.util.compat.Directive class is now deprecated. Please
+#      use instead docutils.parsers.rst.Directive
+#
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=896485#12
+sphinxcontrib.plantuml>=0.11,<0.25
 
 
 # Differences between these "lax" version requirements and the official


### PR DESCRIPTION
- Version 0.11 is the first version that supports
  plantuml_output_format=none which makes the build instant. https://pypi.org/project/sphinxcontrib-plantuml/0.11/

 - 0.24 is the last version successfully tested with
  PIP_IGNORE_INSTALLED=0 and Ubuntu 20.04 (see .github/worflows/)

Signed-off-by: Marc Herbert <marc.herbert@intel.com>