### PR TITLE
Finally document how to achieve instant builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,11 @@ apidocs:
 ifeq (${APIS_CMAKE},$(wildcard ${APIS_CMAKE}))
 	ninja -C ${SOF_DOC_BUILD} $${VERBOSE:+-v} doc
 else
-	# To build doxygen APIs too run this first:
+	# To include doxygen APIs run this first:
 	#   cmake -GNinja -S ../sof/doc -B ${SOF_DOC_BUILD}
+	# Note this will make the build CONSIDERABLY LONGER!
+	# Conversely, you can have _instant builds from scratch_
+	# by disabling UML diagrams in the conf.py file.
 endif
 
 html: apidocs

--- a/conf.py
+++ b/conf.py
@@ -45,8 +45,13 @@ graphviz_dot_args=[
 plantuml = 'java -jar ' + os.path.join(os.path.abspath('.'), 'scripts/plantuml.jar') \
     + ' -config ' + os.path.join(os.path.abspath('.'), 'scripts/plantuml.cfg')
 
-# Temporarily set this to "none" for a build without diagrams but ~= 15
-# times faster from scratch.
+# More than half of the time building from scratch is consumed by the
+# sphinx extension "breathe" that converts doxygen XML. Most of the rest
+# is consumed by plantUML here. So you can set the variable below to
+# 'none' for an _almost instant_ sphinx build! (with zero UML diagram
+# and no doxygen). 'none' requires sphinxcontrib.plantuml>=0.11 but
+# pre-0.11 errors can be ignored.  (of course don't disable UML when
+# you're touching UML stuff)
 plantuml_output_format = 'svg'
 
 # Add any paths that contain templates here, relative to this directory.

--- a/scripts/requirements-lax.txt
+++ b/scripts/requirements-lax.txt
@@ -13,7 +13,21 @@ breathe>=4.7.3
 sphinx>=1.6.7
 docutils>=0.14
 sphinx_rtd_theme>=0.2.4
-sphinxcontrib-plantuml
+
+# - Version 0.11 is the first version that supports
+#   `plantuml_output_format=none` which is required for instant builds.
+#   https://pypi.org/project/sphinxcontrib-plantuml/0.11/
+#
+# - 0.24 is the last version successfully tested with
+#   PIP_IGNORE_INSTALLED=0 and Ubuntu 20.04 (see .github/worflows/)
+#
+# - Note 0.9 is the minimum to fix this fatal import failure:
+#
+#   sphinx.util.compat.Directive class is now deprecated. Please
+#      use instead docutils.parsers.rst.Directive
+#
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=896485#12
+sphinxcontrib.plantuml>=0.11,<0.25
 
 
 # Differences between these "lax" version requirements and the official


### PR DESCRIPTION
Without instant builds there is no drive-by contributor submitting
quick fixes.

Also update requirements-lax.txt to request
sphinxcontrib.plantuml>=0.11,<0.25

- Version 0.11 is the first version that supports
  plantuml_output_format=none which makes the build at least 15
  times faster. https://pypi.org/project/sphinxcontrib-plantuml/0.11/

 - 0.24 is the last version successfully tested with
  PIP_IGNORE_INSTALLED=0 and Ubuntu 20.04 (see .github/worflows/)

Signed-off-by: Marc Herbert <marc.herbert@intel.com>