### PR TITLE
getting_started: add information and links for HDAudio command snooping

### DIFF
--- a/getting_started/intel_debug/suggestions.rst
+++ b/getting_started/intel_debug/suggestions.rst
@@ -22,24 +22,41 @@ snd-intel-dspcfg dsp_driver=1" to ``/etc/modprobe.d/alsa-base.conf``.
 If no sound can be heard and jack detection is not functional, an
 HDaudio external codec configuration is likely. In some cases, the
 Linux drivers are missing configuration information and may only
-enable two of the four speakers present. All of these cases are orthogonal
-to SOF issues in that the SOF driver cannot compensate for codec driver
-problems on its own.
+enable two of the four speakers present.
+
+All of these cases are orthogonal to SOF issues in that the SOF driver
+cannot compensate for codec driver problems on its own. The HDaudio
+codec configuration is handled by the legacy HDAudio driver
+(snd-hda-intel), which is not maintained directly by SOF developers.
 
 Try booting into Windows first, then reboot into Linux
 ******************************************************
 
-On some platforms, such as with an HDaudio codec connected to amplifiers
-over an I2C/I2S link, the codec driver needs to perform a set of
-amplifier configurations. This is often handled in Windows but not in
-Linux codec drivers. A classic example of such issues is when
+On some platforms, such as with an HDaudio codec connected to
+amplifiers over an I2C/I2S link, the codec driver needs to perform a
+set of amplifier configurations. This is often handled in Windows but
+not in Linux codec drivers. A classic example of such issues is when
 headphone playback works, but speaker playback does not (or not on all
-speakers).
+speakers). Booting first in Windows then rebooting in Linux may help
+setup the right configuration, but additional work is needed to patch
+the Linux kernel.
 
-These types of issues also occur with the HDaudio legacy driver
-and are not part of SOF bugs proper. To fix such issues, either obtain
-direct support from the codec vendor, or reverse-engineer the missing
-configuration by snooping HDaudio commands in a Windows environment.
+Reverse-engineer the Windows audio driver
+*****************************************
+
+The HDaudio driver configures the codec with 'verb' commands to
+e.g. setup the 'pins' or a coefficient. The exact values used are
+device-specific, and in the absence of any documentation from the
+codec vendor need to be reverse-engineered by snooping HDAudio
+commands in a Windows environment.
+
+The following links provide additional information on snooping the
+commands and determining what needs to be added to the Linux
+kernel. These links are not maintained by SOF developers.
+
+* `ASUS Linux blog <https://asus-linux.org/blog/sound-2021-01-11/>`_
+
+* `How to sniff verbs from a Windows sound driver <https://github.com/ryanprescott/realtek-verb-tools/wiki/How-to-sniff-verbs-from-a-Windows-sound-driver>`_
 
 Make sure the ME is enabled
 ***************************


### PR DESCRIPTION
Add information provided by end-users who reversed-engineered the Windows audio driver configuration.

Link: https://github.com/thesofproject/linux/issues/4176
Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>