### PR TITLE
arch: fw: cleanup links in memory management overview

### DIFF
--- a/architectures/firmware/sof-zephyr/rtos_layer/memory_management/index.rst
+++ b/architectures/firmware/sof-zephyr/rtos_layer/memory_management/index.rst
@@ -11,17 +11,12 @@ Overview
 
 The memory support functionality is delivered at two levels:
 
-  - `Zephyr Memory Management Service <https://docs.zephyrproject.org/latest/kernel/memory_management/index.html>`__,
+  - Zephyr Memory Management Service, which provides memory drivers, demand
+    paging, allocators, and heap management,
 
-    - `Memory Blocks Allocator <https://docs.zephyrproject.org/latest/kernel/memory_management/sys_mem_blocks.html>`__,
-    - `Memory Management driver <https://docs.zephyrproject.org/latest/doxygen/html/group__mm__drv__apis.html>`__,
-    - `Heaps Management <https://docs.zephyrproject.org/latest/kernel/memory_management/shared_multi_heap.html>`__,
-    - `Demand Paging <https://docs.zephyrproject.org/latest/kernel/memory_management/demand_paging.html>`__,
-
-  - MPP Memory Management - SOF extension,
-
-    - Memory Heaps initialization for supported memory zones,
-    - Memory allocation from selectable memory zones,
+  - MPP Memory Management - SOF extension, which provides heaps for virtual
+    memory mapped to physical memory on demand, and declaration of SOF specific
+    heaps instantiated for various memory zones,
 
 .. uml:: images/memory_management_layers.pu
    :caption: Example of Memory Management layers and interfaces
@@ -37,3 +32,12 @@ Read More
    heap_sharing
    memory_management_driver
    memory_management_flows
+
+External Links
+==============
+
+-  `Zephyr Memory Management Service <https://docs.zephyrproject.org/latest/kernel/memory_management/index.html>`__
+-  `Memory Blocks Allocator <https://docs.zephyrproject.org/latest/kernel/memory_management/sys_mem_blocks.html>`__
+-  `Memory Management driver <https://docs.zephyrproject.org/latest/doxygen/html/group__mm__drv__apis.html>`__
+-  `Heaps Management <https://docs.zephyrproject.org/latest/kernel/memory_management/shared_multi_heap.html>`__
+-  `Demand Paging <https://docs.zephyrproject.org/latest/kernel/memory_management/demand_paging.html>`__


### PR DESCRIPTION
Initial description was unbalanced. One section contained links while the other had the links moved to the Read More section below the diagram.

Now all the links are moved to the Read More. External links are annotated to let the reader know that opening results in move to another website.