### PR TITLE
Supported Platforms: add mt8188 mediatek platform information

### DIFF
--- a/platforms/index.rst
+++ b/platforms/index.rst
@@ -32,6 +32,7 @@ Platform and board specific support is continually added to the SOF project as d
    "AMD Rembrandt", "Xtensa HiFi5", "1 @ 200-800MHz", "TBD", "1.75 MB HP SRAM / 512 KB IRAM/DRAM", "1 x SP (I2S, PCM), 1 x BT (I2S, PCM), 1 x HS(I2S, PCM), DMIC"
    "Mediatek mt8195", "Xtensa HiFi4", "1 @ 220 - 720MHz", "TBD", "256 KB SRAM / 16 MB DRAM", "2 x TDM Out, 1 x TDM In, DMIC"
    "Mediatek mt8186", "Xtensa HiFi5", "1 @ 300 - 800MHz", "TBD", "512 KB SRAM / DRAM", "2 x I2S Out, 1 x I2S In, DMIC"
+   "Mediatek mt8188", "Xtensa HiFi5", "1 @ 26 - 800MHz", "TBD", "512 KB SRAM / 17 MB DRAM", "2 x TDM Out, 1 x TDM In, DMIC"
 
 When support for a new platform is being added, certain interfaces required by
 SOF infrastructure must be implemented. Refer to Platform API documentation


### PR DESCRIPTION
Add mt8188 mediatek platform information to the table. Included clock, memory and audio controller instances to the table