### PR TITLE
Workaround for warning "'ImageDraw' object has no attribute 'textsize'" with pillow 10.0.0

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -32,7 +32,7 @@ jobs:
   supported-reqs:
 
     name: 'Supported scripts/requirements.txt'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
@@ -81,7 +81,7 @@ jobs:
 
   deploy:
     needs: supported-reqs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/publish' }}
     steps:
       # download the build result from the same workflow

--- a/scripts/requirements-lax.txt
+++ b/scripts/requirements-lax.txt
@@ -9,9 +9,9 @@
 #  PIP_IGNORE_INSTALLED=0 pip3 install --user -r scripts/requirements-lax.txt
 # See https://github.com/pypa/pip/issues/4222
 
-breathe>=4.7.3
-sphinx>=1.6.7
-docutils>=0.14
+breathe>=4.29.2
+sphinx>=4.5.0
+docutils>=0.17.1
 sphinx_rtd_theme>=0.2.4
 sphinxcontrib-blockdiag>=3.0.0
 
@@ -19,16 +19,13 @@ sphinxcontrib-blockdiag>=3.0.0
 #   `plantuml_output_format=none` which is required for instant builds.
 #   https://pypi.org/project/sphinxcontrib-plantuml/0.11/
 #
-# - 0.24 is the last version successfully tested with
-#   PIP_IGNORE_INSTALLED=0 and Ubuntu 20.04 (see .github/worflows/)
-#
 # - Note 0.9 is the minimum to fix this fatal import failure:
 #
 #   sphinx.util.compat.Directive class is now deprecated. Please
 #      use instead docutils.parsers.rst.Directive
 #
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=896485#12
-sphinxcontrib.plantuml>=0.11,<0.25
+sphinxcontrib.plantuml>=0.11
 
 # Differences between these "lax" version requirements and the official
 # ones in requirements.txt:

--- a/scripts/requirements-lax.txt
+++ b/scripts/requirements-lax.txt
@@ -58,3 +58,8 @@ sphinxcontrib.plantuml>=0.11,<0.25
 #  - Downgrade if successfully tested.
 #  - Test with plantum set to "none" in conf.py. We don't want small
 #    typo fixes to depend on UML diagrams.
+
+# Workaround for warning "'ImageDraw' object has no attribute 'textsize'"
+# with pillow 10.0.0, see
+# https://github.com/thesofproject/sof-docs/issues/472
+pillow<10

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -6,3 +6,9 @@ docutils==0.17.1
 sphinx_rtd_theme
 sphinxcontrib-plantuml
 sphinxcontrib-blockdiag
+
+
+# Workaround for warning "'ImageDraw' object has no attribute 'textsize'"
+# with pillow 10.0.0, see
+# https://github.com/thesofproject/sof-docs/issues/472
+pillow<10


### PR DESCRIPTION
3 commits, see commit message