### PR TITLE
rtos: io_drivers: add loopback mode description

### DIFF
--- a/architectures/firmware/sof-zephyr/rtos_layer/io_drivers/i2s/i2s_driver.rst
+++ b/architectures/firmware/sof-zephyr/rtos_layer/io_drivers/i2s/i2s_driver.rst
@@ -119,7 +119,6 @@ loopbacks (LBM, loopback mode) - the receiver always does see what the sender is
 Please note the following: 
 
  - all the parameters of transmitter and receiver, like number of channels, data rates, and format must match each other
-and format, must match each other
  - the lines are connected internally, so LBM mode may be used even if the I2S pins are not 
 physically available
 

--- a/architectures/firmware/sof-zephyr/rtos_layer/io_drivers/i2s/i2s_driver.rst
+++ b/architectures/firmware/sof-zephyr/rtos_layer/io_drivers/i2s/i2s_driver.rst
@@ -112,7 +112,7 @@ the I2S IO Driver.
 Loopback mode
 ======================================
 
-I2S transmitter and receiver share data pins at IP level - the Tx pin of the transmitter 
+The I2S transmitter and receiver share data pins at the IP level. The Tx pin of the transmitter 
 is connected to the Rx pin of the receiver. This may be used for easy creation of digital 
 loopbacks (LBM, loopback mode) - the receiver always does see what the sender is sending. 
 

--- a/architectures/firmware/sof-zephyr/rtos_layer/io_drivers/i2s/i2s_driver.rst
+++ b/architectures/firmware/sof-zephyr/rtos_layer/io_drivers/i2s/i2s_driver.rst
@@ -116,7 +116,7 @@ The I2S transmitter and receiver share data pins at the IP level. The Tx pin of 
 is connected to the Rx pin of the receiver. This may be used for easy creation of digital 
 loopbacks (LBM, loopback mode) - the receiver always does see what the sender is sending. 
 
-Please note that 
+Please note the following: 
 
  - all the parameters of transmitter and receiver, like number of channels, data rates 
 and format, must match each other

--- a/architectures/firmware/sof-zephyr/rtos_layer/io_drivers/i2s/i2s_driver.rst
+++ b/architectures/firmware/sof-zephyr/rtos_layer/io_drivers/i2s/i2s_driver.rst
@@ -108,3 +108,18 @@ stream with already running ones.
 
 "Single" I2S links may be synchronized and aggregated by sending I2sSyncData to
 the I2S IO Driver.
+
+Loopback mode
+======================================
+
+I2S transmitter and receiver share data pins at IP level - the Tx pin of the transmitter 
+is connected to the Rx pin of the receiver. This may be used for easy creation of digital 
+loopbacks (LBM, loopback mode) - the receiver always does see what the sender is sending. 
+
+Please note that 
+
+ - all the parameters of transmitter and receiver, like number of channels, data rates 
+and format, must match each other
+ - the lines are connected internally, so LBM mode may be used even if the I2S pins are not 
+physically available
+

--- a/architectures/firmware/sof-zephyr/rtos_layer/io_drivers/i2s/i2s_driver.rst
+++ b/architectures/firmware/sof-zephyr/rtos_layer/io_drivers/i2s/i2s_driver.rst
@@ -118,7 +118,7 @@ loopbacks (LBM, loopback mode) - the receiver always does see what the sender is
 
 Please note the following: 
 
- - all the parameters of transmitter and receiver, like number of channels, data rates 
+ - all the parameters of transmitter and receiver, like number of channels, data rates, and format must match each other
 and format, must match each other
  - the lines are connected internally, so LBM mode may be used even if the I2S pins are not 
 physically available

--- a/architectures/firmware/sof-zephyr/rtos_layer/io_drivers/i2s/i2s_driver.rst
+++ b/architectures/firmware/sof-zephyr/rtos_layer/io_drivers/i2s/i2s_driver.rst
@@ -119,6 +119,6 @@ loopbacks (LBM, loopback mode) - the receiver always does see what the sender is
 Please note the following: 
 
  - all the parameters of transmitter and receiver, like number of channels, data rates, and format must match each other
- - the lines are connected internally, so LBM mode may be used even if the I2S pins are not 
+ - the lines are connected internally, so LBM mode may be used even if the I2S pins are not physically available
 physically available
 

--- a/architectures/firmware/sof-zephyr/rtos_layer/io_drivers/i2s/i2s_driver.rst
+++ b/architectures/firmware/sof-zephyr/rtos_layer/io_drivers/i2s/i2s_driver.rst
@@ -120,5 +120,4 @@ Please note the following:
 
  - all the parameters of transmitter and receiver, like number of channels, data rates, and format must match each other
  - the lines are connected internally, so LBM mode may be used even if the I2S pins are not physically available
-physically available
 


### PR DESCRIPTION
This commit adds a description of using SSP devices in loopback mode