### PR TITLE
Fix pull-request.yml build errors by addressing Sphinx warnings and adding missing label definition

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -136,7 +136,6 @@ else:
         'canonical_url': '',
         'analytics_id': 'GTM-M4BL5NF',
         'logo_only': False,
-        'display_version': True,
         'prev_next_buttons_location': 'None',
         # Toc options
         'collapse_navigation': False,

--- a/conf.py
+++ b/conf.py
@@ -132,7 +132,6 @@ except ImportError:
     sys.stderr.write('Warning: sphinx_rtd_theme missing. Use pip to install it.\n')
 else:
     html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
     html_theme_options = {
         'canonical_url': '',
         'analytics_id': 'GTM-M4BL5NF',

--- a/developer_guides/firmware/llext_modules.rst
+++ b/developer_guides/firmware/llext_modules.rst
@@ -78,7 +78,7 @@ Installation
 ************
 
 As specified in
-:ref:`Firmware look-up paths per Intel platform <intel_firmware_paths>`
+:ref:`Firmware look-up paths per Intel platform <intel_modular_firmware_paths>`
 the |SOF| Linux kernel driver loads SOF modules by their UUIDs,
 specified in the topology. For SOF in-tree modules the process of creation and
 installation of modules in a deployment tree is automated by the


### PR DESCRIPTION
This pull request addresses the build errors caused by Sphinx warnings and a missing label definition in the documentation. The following changes have been made:

1. **Update link to  for `intel_modular_firmware_paths`**:
   - Updated the link from `intel_firmware_paths` to `intel_modular_firmware_paths` in `developer_guides/firmware/llext_modules.rst` to resolve the docs build error.
   - Commit: dc0495a29f68fcdf5e88f97d83b400d0e49c4b41

2. **Remove deprecated `display_version` configuration**:
   - Removed the `display_version` option from `html_theme_options` in `conf.py` as it was deprecated in `sphinx-rtd-theme` since v3.0.0.
   - Commit: eec6e47c7c4b780bd8e1ac0624334c30785d867c

3. **Remove unused `html_theme_path` configuration**:
   - Removed the unused `html_theme_path` configuration from `conf.py` to get rid of the deprecation warning.
   - Commit: 36eafc14b95861cf0ee027b42db9f1fab73b8c0c

These changes should resolve the build errors and ensure that the documentation builds successfully without warnings.

### Changes
- `developer_guides/firmware/llext_modules.rst`: Fixed link to `intel_modular_firmware_paths`.
- `conf.py`: Removed deprecated `display_version` configuration and unused `html_theme_path` configuration.

### Signed-off-by
Christopher Turner <christopher.g.turner@intel.com>